### PR TITLE
feat: explicit cluster syntax

### DIFF
--- a/ecsact_interpret/ecsact/interpret/detail/eval_parse.hh
+++ b/ecsact_interpret/ecsact/interpret/detail/eval_parse.hh
@@ -2,6 +2,7 @@
 
 #include <filesystem>
 #include <array>
+#include <span>
 #include <unordered_set>
 #include <cassert>
 #include <iostream> //  TODO(ZAUCY): Remove this
@@ -444,8 +445,11 @@ void parse_eval_declarations(
 			ecsact::detail::check_file_eval_error(
 				eval_err,
 				*file_state.package_id,
-				file_state.reader.status,
-				*file_state.reader.current_context,
+				file_state.reader.status.code,
+				std::span(
+					file_state.reader.statements.data(),
+					file_state.reader.statements.size()
+				),
 				""
 			);
 		}

--- a/ecsact_interpret/ecsact/interpret/detail/eval_parse.hh
+++ b/ecsact_interpret/ecsact/interpret/detail/eval_parse.hh
@@ -20,7 +20,7 @@
 template<>
 struct magic_enum::customize::enum_range<ecsact_eval_error_code> {
 	static constexpr int min = 0;
-	static constexpr int max = 2000;
+	static constexpr int max = 2001;
 };
 
 namespace ecsact::detail {

--- a/ecsact_interpret/ecsact/interpret/detail/file_eval_error.hh
+++ b/ecsact_interpret/ecsact/interpret/detail/file_eval_error.hh
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <span>
 #include "ecsact/interpret/eval.h"
 
 #include "./fixed_stack.hh"
@@ -8,11 +9,11 @@
 namespace ecsact::detail {
 
 void check_file_eval_error(
-	ecsact_eval_error&      in_out_error,
-	ecsact_package_id       package_id,
-	ecsact_parse_status     status,
-	const ecsact_statement& statement,
-	const std::string&      source
+	ecsact_eval_error&                in_out_error,
+	ecsact_package_id                 package_id,
+	ecsact_parse_status_code          status_code,
+	std::span<const ecsact_statement> statement_stack,
+	const std::string&                source
 );
 
 }

--- a/ecsact_interpret/ecsact/interpret/eval.cc
+++ b/ecsact_interpret/ecsact/interpret/eval.cc
@@ -920,6 +920,13 @@ static ecsact_eval_error eval_system_statement(
 		ecsact_add_child_system(*parent_sys_like_id, sys_id);
 	}
 
+	if(context != nullptr && context->type == ECSACT_STATEMENT_CLUSTER) {
+		ecsact_add_system_to_cluster(
+			static_cast<ecsact_cluster_id>(context->id),
+			static_cast<ecsact_system_like_id>(sys_id)
+		);
+	}
+
 	if(lazy_value > 0) {
 		ecsact_set_system_lazy_iteration_rate(sys_id, lazy_value);
 	}
@@ -980,6 +987,13 @@ static ecsact_eval_error eval_action_statement(
 	);
 
 	statement.id = static_cast<int32_t>(act_id);
+
+	if(context != nullptr && context->type == ECSACT_STATEMENT_CLUSTER) {
+		ecsact_add_system_to_cluster(
+			static_cast<ecsact_cluster_id>(context->id),
+			static_cast<ecsact_system_like_id>(act_id)
+		);
+	}
 
 	auto parallel = parallel_param(statement);
 	if(auto err_code = std::get_if<ecsact_eval_error_code>(&parallel)) {
@@ -1991,16 +2005,17 @@ static ecsact_eval_error eval_entity_constraint_statement(
 static ecsact_eval_error eval_cluster_statement(
 	ecsact_package_id                 package_id,
 	std::span<const ecsact_statement> context_statements,
-	const ecsact_statement&           statement
+	ecsact_statement&                 statement
 ) {
 	auto& cluster_statement = statement.data.cluster_statement;
 
 	if(context_statements.empty()) {
-		ecsact_add_cluster(
+		auto id = ecsact_create_cluster(
 			package_id,
 			cluster_statement.cluster_name.data,
 			cluster_statement.cluster_name.length
 		);
+		statement.id = static_cast<int32_t>(id);
 	} else {
 		auto parent_ctx = &context_statements.back();
 		auto parent_sys_like_id =
@@ -2014,11 +2029,12 @@ static ecsact_eval_error eval_cluster_statement(
 			};
 		}
 
-		ecsact_add_system_cluster(
+		auto id = ecsact_create_system_cluster(
 			*parent_sys_like_id,
 			cluster_statement.cluster_name.data,
 			cluster_statement.cluster_name.length
 		);
+		statement.id = static_cast<int32_t>(id);
 	}
 
 	return {ECSACT_EVAL_OK};
@@ -2209,18 +2225,6 @@ void ecsact::detail::check_file_eval_error(
 					.data = source.c_str(),
 					.length = static_cast<int32_t>(source.size()),
 				};
-			}
-		}
-
-		if(block_start.type == ECSACT_STATEMENT_CLUSTER) {
-			std::span context_stack(statement_stack.data(), statement_stack.size() - 2);
-			auto     parent_sys_like_id =
-				find_parent_system_like_id(package_id, context_stack);
-
-			if(parent_sys_like_id) {
-				ecsact_end_system_cluster(*parent_sys_like_id);
-			} else {
-				ecsact_end_cluster(package_id);
 			}
 		}
 	}

--- a/ecsact_interpret/ecsact/interpret/eval.cc
+++ b/ecsact_interpret/ecsact/interpret/eval.cc
@@ -660,6 +660,8 @@ std::optional<ecsact_system_like_id> find_by_statement(
 					)
 				)
 			);
+		case ECSACT_STATEMENT_CLUSTER:
+			return std::nullopt;
 		default:
 			break;
 	}
@@ -827,10 +829,24 @@ static ecsact_eval_error eval_transient_statement(
 	return {};
 }
 
+static std::optional<ecsact_system_like_id> find_parent_system_like_id(
+	ecsact_package_id                 package_id,
+	std::span<const ecsact_statement> context_stack
+) {
+	for(int32_t i = static_cast<int32_t>(context_stack.size()) - 1; i >= 0; --i) {
+		auto& context = context_stack[i];
+		if(context.type == ECSACT_STATEMENT_CLUSTER) {
+			continue;
+		}
+		return find_by_statement<ecsact_system_like_id>(package_id, context);
+	}
+	return std::nullopt;
+}
+
 static ecsact_eval_error eval_system_statement(
 	ecsact_package_id                  package_id,
 	std::span<const ecsact_statement>& context_stack,
-	const ecsact_statement&            statement
+	ecsact_statement&                  statement
 ) {
 	auto& data = statement.data.system_statement;
 	auto  parent_sys_like_id = std::optional<ecsact_system_like_id>{};
@@ -840,6 +856,7 @@ static ecsact_eval_error eval_system_statement(
 			ECSACT_STATEMENT_NONE,
 			ECSACT_STATEMENT_SYSTEM,
 			ECSACT_STATEMENT_ACTION,
+			ECSACT_STATEMENT_CLUSTER,
 		}
 	);
 
@@ -872,9 +889,8 @@ static ecsact_eval_error eval_system_statement(
 	}();
 
 	if(context != nullptr) {
-		parent_sys_like_id =
-			find_by_statement<ecsact_system_like_id>(package_id, *context);
-		if(!parent_sys_like_id) {
+		parent_sys_like_id = find_parent_system_like_id(package_id, context_stack);
+		if(!parent_sys_like_id && context->type != ECSACT_STATEMENT_CLUSTER) {
 			return ecsact_eval_error{
 				.code = ECSACT_EVAL_ERR_INVALID_CONTEXT,
 				.relevant_content = {},
@@ -897,6 +913,8 @@ static ecsact_eval_error eval_system_statement(
 		data.system_name.data,
 		data.system_name.length
 	);
+
+	statement.id = static_cast<int32_t>(sys_id);
 
 	if(parent_sys_like_id) {
 		ecsact_add_child_system(*parent_sys_like_id, sys_id);
@@ -925,10 +943,16 @@ static ecsact_eval_error eval_system_statement(
 static ecsact_eval_error eval_action_statement(
 	ecsact_package_id                  package_id,
 	std::span<const ecsact_statement>& context_stack,
-	const ecsact_statement&            statement
+	ecsact_statement&                  statement
 ) {
 	auto& data = statement.data.action_statement;
-	auto [context, err] = expect_context(context_stack, {ECSACT_STATEMENT_NONE});
+	auto [context, err] = expect_context(
+		context_stack,
+		{
+			ECSACT_STATEMENT_NONE,
+			ECSACT_STATEMENT_CLUSTER,
+		}
+	);
 	if(err.code != ECSACT_EVAL_OK) {
 		err.relevant_content = data.action_name;
 		return err;
@@ -954,6 +978,8 @@ static ecsact_eval_error eval_action_statement(
 		data.action_name.data,
 		data.action_name.length
 	);
+
+	statement.id = static_cast<int32_t>(act_id);
 
 	auto parallel = parallel_param(statement);
 	if(auto err_code = std::get_if<ecsact_eval_error_code>(&parallel)) {
@@ -1962,17 +1988,56 @@ static ecsact_eval_error eval_entity_constraint_statement(
 	return {};
 }
 
+static ecsact_eval_error eval_cluster_statement(
+	ecsact_package_id                 package_id,
+	std::span<const ecsact_statement> context_statements,
+	const ecsact_statement&           statement
+) {
+	auto& cluster_statement = statement.data.cluster_statement;
+
+	if(context_statements.empty()) {
+		ecsact_meta_add_cluster(
+			package_id,
+			cluster_statement.cluster_name.data,
+			cluster_statement.cluster_name.length
+		);
+	} else {
+		auto parent_ctx = &context_statements.back();
+		auto parent_sys_like_id =
+			find_by_statement<ecsact_system_like_id>(package_id, *parent_ctx);
+
+		if(!parent_sys_like_id) {
+			return ecsact_eval_error{
+				.code = ECSACT_EVAL_ERR_INVALID_CONTEXT,
+				.relevant_content = {},
+				.context_type = parent_ctx->type,
+			};
+		}
+
+		ecsact_meta_add_system_cluster(
+			*parent_sys_like_id,
+			cluster_statement.cluster_name.data,
+			cluster_statement.cluster_name.length
+		);
+	}
+
+	return {ECSACT_EVAL_OK};
+}
+
 ecsact_eval_error ecsact_eval_statement(
-	ecsact_package_id       package_id,
-	int32_t                 statement_stack_size,
-	const ecsact_statement* statement_stack
+	ecsact_package_id package_id,
+	int32_t           statement_stack_size,
+	ecsact_statement* statement_stack
 ) {
 	if(statement_stack_size == 0) {
 		return {};
 	}
 
 	auto&     statement = statement_stack[statement_stack_size - 1];
-	std::span context_statements(statement_stack, statement_stack_size - 1);
+	std::span context_statements(
+		const_cast<const ecsact_statement*>(statement_stack),
+		statement_stack_size - 1
+	);
 
 	auto err = [&]() -> std::optional<ecsact_eval_error> {
 		switch(statement.type) {
@@ -2069,9 +2134,18 @@ ecsact_eval_error ecsact_eval_statement(
 					context_statements,
 					statement
 				);
+			case ECSACT_STATEMENT_CLUSTER:
+				return eval_cluster_statement(
+					package_id,
+					context_statements,
+					statement
+				);
 		}
 
-		return std::nullopt;
+		return ecsact_eval_error{
+			.code = ECSACT_EVAL_ERR_UNEXPECTED_STATEMENT,
+			.relevant_content = {},
+		};
 	}();
 
 	if(!err) {
@@ -2102,17 +2176,26 @@ void ecsact_eval_reset() {
 }
 
 void ecsact::detail::check_file_eval_error(
-	ecsact_eval_error&      in_out_error,
-	ecsact_package_id       package_id,
-	ecsact_parse_status     status,
-	const ecsact_statement& statement,
-	const std::string&      source
+	ecsact_eval_error&                in_out_error,
+	ecsact_package_id                 package_id,
+	ecsact_parse_status_code          status_code,
+	std::span<const ecsact_statement> statement_stack,
+	const std::string&                source
 ) {
 	assert(in_out_error.code == ECSACT_EVAL_OK);
 
-	if(status.code == ECSACT_PARSE_STATUS_BLOCK_END) {
-		if(statement.type == ECSACT_STATEMENT_ACTION) {
-			auto& data = statement.data.action_statement;
+	if(statement_stack.empty()) {
+		return;
+	}
+
+	if(status_code == ECSACT_PARSE_STATUS_BLOCK_END) {
+		if(statement_stack.size() < 2) {
+			return;
+		}
+
+		auto& block_start = statement_stack[statement_stack.size() - 2];
+		if(block_start.type == ECSACT_STATEMENT_ACTION) {
+			auto& data = block_start.data.action_statement;
 
 			auto act_id = find_by_name<ecsact_action_id>(
 				package_id,
@@ -2126,6 +2209,18 @@ void ecsact::detail::check_file_eval_error(
 					.data = source.c_str(),
 					.length = static_cast<int32_t>(source.size()),
 				};
+			}
+		}
+
+		if(block_start.type == ECSACT_STATEMENT_CLUSTER) {
+			std::span context_stack(statement_stack.data(), statement_stack.size() - 2);
+			auto     parent_sys_like_id =
+				find_parent_system_like_id(package_id, context_stack);
+
+			if(parent_sys_like_id) {
+				ecsact_meta_end_system_cluster(*parent_sys_like_id);
+			} else {
+				ecsact_meta_end_cluster(package_id);
 			}
 		}
 	}

--- a/ecsact_interpret/ecsact/interpret/eval.cc
+++ b/ecsact_interpret/ecsact/interpret/eval.cc
@@ -1996,7 +1996,7 @@ static ecsact_eval_error eval_cluster_statement(
 	auto& cluster_statement = statement.data.cluster_statement;
 
 	if(context_statements.empty()) {
-		ecsact_meta_add_cluster(
+		ecsact_add_cluster(
 			package_id,
 			cluster_statement.cluster_name.data,
 			cluster_statement.cluster_name.length
@@ -2014,7 +2014,7 @@ static ecsact_eval_error eval_cluster_statement(
 			};
 		}
 
-		ecsact_meta_add_system_cluster(
+		ecsact_add_system_cluster(
 			*parent_sys_like_id,
 			cluster_statement.cluster_name.data,
 			cluster_statement.cluster_name.length
@@ -2218,9 +2218,9 @@ void ecsact::detail::check_file_eval_error(
 				find_parent_system_like_id(package_id, context_stack);
 
 			if(parent_sys_like_id) {
-				ecsact_meta_end_system_cluster(*parent_sys_like_id);
+				ecsact_end_system_cluster(*parent_sys_like_id);
 			} else {
-				ecsact_meta_end_cluster(package_id);
+				ecsact_end_cluster(package_id);
 			}
 		}
 	}

--- a/ecsact_interpret/ecsact/interpret/eval.h
+++ b/ecsact_interpret/ecsact/interpret/eval.h
@@ -27,9 +27,9 @@ ecsact_package_id ecsact_eval_package_statement(
  * @returns error details
  */
 ecsact_eval_error ecsact_eval_statement(
-	ecsact_package_id       package_id,
-	int32_t                 statement_stack_size,
-	const ecsact_statement* statement_stack
+	ecsact_package_id package_id,
+	int32_t           statement_stack_size,
+	ecsact_statement* statement_stack
 );
 
 ECSACT_DEPRECATED("unneeded since interpreter does not hold state")

--- a/ecsact_interpret/ecsact/interpret/eval_error.h
+++ b/ecsact_interpret/ecsact/interpret/eval_error.h
@@ -91,6 +91,9 @@ typedef enum ecsact_eval_error_code {
 	/// Field type is not allowed in 'with' statement
 	ECSACT_EVAL_ERR_INVALID_ASSOC_FIELD_TYPE,
 
+	/// System cannot be part of the explicit cluster it is in
+	ECSACT_EVAL_ERR_INVALID_CLUSTER_SYSTEM,
+
 	/// Internal error. Should not happen and is an indiciation of a bug.
 	ECSACT_EVAL_ERR_INTERNAL = 999,
 

--- a/ecsact_interpret/ecsact/interpret/eval_files.cc
+++ b/ecsact_interpret/ecsact/interpret/eval_files.cc
@@ -7,6 +7,8 @@
 #include <utility>
 #include "ecsact/parse.h"
 #include "ecsact/interpret/eval.h"
+#include "ecsact/runtime/meta.h"
+#include "ecsact/runtime/meta.hh"
 
 #include "./detail/check_set.hh"
 #include "./detail/fixed_stack.hh"
@@ -17,6 +19,42 @@
 
 namespace fs = std::filesystem;
 using ecsact::parse_eval_error;
+using namespace ecsact::detail;
+
+static void check_batches(
+	int32_t                        source_index,
+	eval_parse_state<std::ifstream>& file_state,
+	std::vector<ecsact::parse_eval_error>& errors
+) {
+	auto package_id = *file_state.package_id;
+	auto invalid_sys_id = ecsact_meta_check_execution_batches(package_id);
+	if(invalid_sys_id != (ecsact_system_like_id)-1) {
+		errors.push_back(ecsact::parse_eval_error{
+			.eval_error = ECSACT_EVAL_ERR_INVALID_CLUSTER_SYSTEM,
+			.source_index = source_index,
+			.line = file_state.reader.current_line,
+			.character = file_state.reader.current_character,
+			.error_message =
+				"System '" + std::string(ecsact_meta_system_name(static_cast<ecsact_system_id>(invalid_sys_id))) + "' cannot be part of the explicit cluster it is in",
+		});
+	}
+
+	for(auto sys_id : ecsact::meta::get_system_ids(package_id)) {
+		auto invalid_nested_sys_id = ecsact_meta_check_system_execution_batches(
+			static_cast<ecsact_system_like_id>(sys_id)
+		);
+		if(invalid_nested_sys_id != (ecsact_system_like_id)-1) {
+			errors.push_back(ecsact::parse_eval_error{
+				.eval_error = ECSACT_EVAL_ERR_INVALID_CLUSTER_SYSTEM,
+				.source_index = source_index,
+				.line = file_state.reader.current_line,
+				.character = file_state.reader.current_character,
+				.error_message =
+					"System '" + std::string(ecsact_meta_system_name(static_cast<ecsact_system_id>(invalid_nested_sys_id))) + "' cannot be part of the explicit cluster it is in",
+			});
+		}
+	}
+}
 
 std::vector<parse_eval_error> ecsact::eval_files(std::vector<fs::path> files) {
 	using ecsact::detail::check_cyclic_imports;
@@ -78,6 +116,11 @@ std::vector<parse_eval_error> ecsact::eval_files(std::vector<fs::path> files) {
 		}
 
 		parse_eval_declarations(source_index, file_state, errors);
+		if(!errors.empty()) {
+			return errors;
+		}
+
+		check_batches(source_index, file_state, errors);
 		if(!errors.empty()) {
 			return errors;
 		}

--- a/ecsact_interpret/ecsact/interpret/eval_files.cc
+++ b/ecsact_interpret/ecsact/interpret/eval_files.cc
@@ -22,21 +22,26 @@ using ecsact::parse_eval_error;
 using namespace ecsact::detail;
 
 static void check_batches(
-	int32_t                        source_index,
-	eval_parse_state<std::ifstream>& file_state,
+	int32_t                                source_index,
+	eval_parse_state<std::ifstream>&       file_state,
 	std::vector<ecsact::parse_eval_error>& errors
 ) {
 	auto package_id = *file_state.package_id;
 	auto invalid_sys_id = ecsact_check_execution_batches(package_id);
 	if(invalid_sys_id != (ecsact_system_like_id)-1) {
-		errors.push_back(ecsact::parse_eval_error{
-			.eval_error = ECSACT_EVAL_ERR_INVALID_CLUSTER_SYSTEM,
-			.source_index = source_index,
-			.line = file_state.reader.current_line,
-			.character = file_state.reader.current_character,
-			.error_message =
-				"System '" + std::string(ecsact_meta_system_name(static_cast<ecsact_system_id>(invalid_sys_id))) + "' cannot be part of the explicit cluster it is in",
-		});
+		errors.push_back(
+			ecsact::parse_eval_error{
+				.eval_error = ECSACT_EVAL_ERR_INVALID_CLUSTER_SYSTEM,
+				.source_index = source_index,
+				.line = file_state.reader.current_line,
+				.character = file_state.reader.current_character,
+				.error_message = "System '" +
+					std::string(ecsact_meta_system_name(
+						static_cast<ecsact_system_id>(invalid_sys_id)
+					)) +
+					"' cannot be part of the explicit cluster it is in",
+			}
+		);
 	}
 
 	for(auto sys_id : ecsact::meta::get_system_ids(package_id)) {
@@ -44,14 +49,19 @@ static void check_batches(
 			static_cast<ecsact_system_like_id>(sys_id)
 		);
 		if(invalid_nested_sys_id != (ecsact_system_like_id)-1) {
-			errors.push_back(ecsact::parse_eval_error{
-				.eval_error = ECSACT_EVAL_ERR_INVALID_CLUSTER_SYSTEM,
-				.source_index = source_index,
-				.line = file_state.reader.current_line,
-				.character = file_state.reader.current_character,
-				.error_message =
-					"System '" + std::string(ecsact_meta_system_name(static_cast<ecsact_system_id>(invalid_nested_sys_id))) + "' cannot be part of the explicit cluster it is in",
-			});
+			errors.push_back(
+				ecsact::parse_eval_error{
+					.eval_error = ECSACT_EVAL_ERR_INVALID_CLUSTER_SYSTEM,
+					.source_index = source_index,
+					.line = file_state.reader.current_line,
+					.character = file_state.reader.current_character,
+					.error_message = "System '" +
+						std::string(ecsact_meta_system_name(
+							static_cast<ecsact_system_id>(invalid_nested_sys_id)
+						)) +
+						"' cannot be part of the explicit cluster it is in",
+				}
+			);
 		}
 	}
 }

--- a/ecsact_interpret/ecsact/interpret/eval_files.cc
+++ b/ecsact_interpret/ecsact/interpret/eval_files.cc
@@ -27,7 +27,7 @@ static void check_batches(
 	std::vector<ecsact::parse_eval_error>& errors
 ) {
 	auto package_id = *file_state.package_id;
-	auto invalid_sys_id = ecsact_meta_check_execution_batches(package_id);
+	auto invalid_sys_id = ecsact_check_execution_batches(package_id);
 	if(invalid_sys_id != (ecsact_system_like_id)-1) {
 		errors.push_back(ecsact::parse_eval_error{
 			.eval_error = ECSACT_EVAL_ERR_INVALID_CLUSTER_SYSTEM,
@@ -40,7 +40,7 @@ static void check_batches(
 	}
 
 	for(auto sys_id : ecsact::meta::get_system_ids(package_id)) {
-		auto invalid_nested_sys_id = ecsact_meta_check_system_execution_batches(
+		auto invalid_nested_sys_id = ecsact_check_system_execution_batches(
 			static_cast<ecsact_system_like_id>(sys_id)
 		);
 		if(invalid_nested_sys_id != (ecsact_system_like_id)-1) {

--- a/ecsact_interpret/parse-resolver-runtime/parse-resolver-runtime.cc
+++ b/ecsact_interpret/parse-resolver-runtime/parse-resolver-runtime.cc
@@ -80,6 +80,8 @@ struct system_like {
 	ecsact_parallel_execution parallel_execution = {};
 
 	std::vector<std::vector<ecsact_system_like_id>> execution_batches;
+	std::vector<int32_t>                            explicit_cluster_starts;
+	std::vector<int32_t>                            explicit_cluster_ends;
 };
 
 struct action_def : composite, system_like {
@@ -126,6 +128,8 @@ struct package_def {
 	std::vector<ecsact_system_like_id> top_level_systems;
 
 	std::vector<std::vector<ecsact_system_like_id>> execution_batches;
+	std::vector<int32_t>                            explicit_cluster_starts;
+	std::vector<int32_t>                            explicit_cluster_ends;
 };
 
 static std::atomic_int32_t                                   last_id = 0;
@@ -1196,6 +1200,8 @@ static bool collect_all_caps(
 
 static void calculate_execution_batches(
 	const std::vector<ecsact_system_like_id>&        systems,
+	const std::vector<int32_t>&                      explicit_starts,
+	const std::vector<int32_t>&                      explicit_ends,
 	std::vector<std::vector<ecsact_system_like_id>>& out_batches
 ) {
 	out_batches.clear();
@@ -1233,7 +1239,12 @@ static void calculate_execution_batches(
 		}
 	};
 
-	for(auto sys_id : systems) {
+	for(int32_t i = 0; static_cast<int32_t>(systems.size()) > i; ++i) {
+		auto sys_id = systems[i];
+		if(std::ranges::find(explicit_starts, i) != explicit_starts.end()) {
+			finalize_batch();
+		}
+
 		std::unordered_map<ecsact_component_like_id, ecsact_system_capability>
 				 all_caps;
 		bool independent = collect_all_caps(sys_id, all_caps);
@@ -1242,8 +1253,7 @@ static void calculate_execution_batches(
 		if(!conflict) {
 			for(auto const& [comp_id, cap] : all_caps) {
 				if(is_exclusive(cap)) {
-					if(batch_readers.contains(comp_id) ||
-						 batch_writers.contains(comp_id)) {
+					if(batch_readers.contains(comp_id) || batch_writers.contains(comp_id)) {
 						conflict = true;
 						break;
 					}
@@ -1274,6 +1284,10 @@ static void calculate_execution_batches(
 		if(independent) {
 			finalize_batch();
 		}
+
+		if(std::ranges::find(explicit_ends, i + 1) != explicit_ends.end()) {
+			finalize_batch();
+		}
 	}
 
 	finalize_batch();
@@ -1294,7 +1308,12 @@ int32_t ecsact_meta_count_execution_batches(ecsact_package_id package_id) {
 		}
 
 		if(!all_systems.empty()) {
-			calculate_execution_batches(all_systems, pkg.execution_batches);
+			calculate_execution_batches(
+				all_systems,
+				pkg.explicit_cluster_starts,
+				pkg.explicit_cluster_ends,
+				pkg.execution_batches
+			);
 		}
 	}
 	return static_cast<int32_t>(pkg.execution_batches.size());
@@ -1321,7 +1340,12 @@ void ecsact_meta_get_execution_batch(
 		}
 
 		if(!all_systems.empty()) {
-			calculate_execution_batches(all_systems, pkg.execution_batches);
+			calculate_execution_batches(
+				all_systems,
+				pkg.explicit_cluster_starts,
+				pkg.explicit_cluster_ends,
+				pkg.execution_batches
+			);
 		}
 	}
 
@@ -1346,7 +1370,12 @@ int32_t ecsact_meta_count_system_execution_batches(
 		for(auto id : sys_def.nested_systems) {
 			nested_systems.push_back(ecsact_id_cast<ecsact_system_like_id>(id));
 		}
-		calculate_execution_batches(nested_systems, sys_def.execution_batches);
+		calculate_execution_batches(
+			nested_systems,
+			sys_def.explicit_cluster_starts,
+			sys_def.explicit_cluster_ends,
+			sys_def.execution_batches
+		);
 	}
 	return static_cast<int32_t>(sys_def.execution_batches.size());
 }
@@ -1364,7 +1393,12 @@ void ecsact_meta_get_system_execution_batch(
 		for(auto id : sys_def.nested_systems) {
 			nested_systems.push_back(ecsact_id_cast<ecsact_system_like_id>(id));
 		}
-		calculate_execution_batches(nested_systems, sys_def.execution_batches);
+		calculate_execution_batches(
+			nested_systems,
+			sys_def.explicit_cluster_starts,
+			sys_def.explicit_cluster_ends,
+			sys_def.execution_batches
+		);
 	}
 
 	auto& batch = sys_def.execution_batches.at(batch_index);
@@ -1385,6 +1419,42 @@ bool ecsact_meta_is_system(ecsact_system_like_id system_id) {
 
 bool ecsact_meta_is_action(ecsact_system_like_id system_id) {
 	return act_defs.contains(static_cast<ecsact_action_id>(system_id));
+}
+
+void ecsact_meta_add_cluster(
+	ecsact_package_id package_id,
+	const char*       cluster_name,
+	int32_t           cluster_name_len
+) {
+	auto& pkg = package_defs.at(package_id);
+	pkg.explicit_cluster_starts.push_back(
+		static_cast<int32_t>(pkg.top_level_systems.size())
+	);
+}
+
+void ecsact_meta_add_system_cluster(
+	ecsact_system_like_id parent_system_id,
+	const char*           cluster_name,
+	int32_t               cluster_name_len
+) {
+	auto& sys = get_system_like(parent_system_id);
+	sys.explicit_cluster_starts.push_back(
+		static_cast<int32_t>(sys.nested_systems.size())
+	);
+}
+
+void ecsact_meta_end_cluster(ecsact_package_id package_id) {
+	auto& pkg = package_defs.at(package_id);
+	pkg.explicit_cluster_ends.push_back(
+		static_cast<int32_t>(pkg.top_level_systems.size())
+	);
+}
+
+void ecsact_meta_end_system_cluster(ecsact_system_like_id parent_system_id) {
+	auto& sys = get_system_like(parent_system_id);
+	sys.explicit_cluster_ends.push_back(
+		static_cast<int32_t>(sys.nested_systems.size())
+	);
 }
 
 auto ecsact_set_component_type( //

--- a/ecsact_interpret/parse-resolver-runtime/parse-resolver-runtime.cc
+++ b/ecsact_interpret/parse-resolver-runtime/parse-resolver-runtime.cc
@@ -210,7 +210,10 @@ ecsact_package_id ecsact_create_package(
 	return id;
 }
 
-void ecsact_add_dependency(ecsact_package_id target, ecsact_package_id dependency) {
+void ecsact_add_dependency(
+	ecsact_package_id target,
+	ecsact_package_id dependency
+) {
 	package_defs.at(target).dependencies.push_back(dependency);
 }
 
@@ -396,7 +399,7 @@ void ecsact_meta_get_system_ids(
 ) {
 	auto& pkg_def = package_defs.at(package_id);
 
-	auto  itr = pkg_def.systems.begin();
+	auto itr = pkg_def.systems.begin();
 	for(int32_t i = 0; max_system_count > i && itr != pkg_def.systems.end();
 			++i) {
 		out_system_ids[i] = *itr;
@@ -511,10 +514,12 @@ ecsact_builtin_type ecsact_meta_enum_storage_type(ecsact_enum_id enum_id) {
 		}
 		return ECSACT_U32;
 	} else {
-		if(min_value >= numeric_limits<int8_t>::min() && max_value <= numeric_limits<int8_t>::max()) {
+		if(min_value >= numeric_limits<int8_t>::min() &&
+			 max_value <= numeric_limits<int8_t>::max()) {
 			return ECSACT_I8;
 		}
-		if(min_value >= numeric_limits<int16_t>::min() && max_value <= numeric_limits<int16_t>::max()) {
+		if(min_value >= numeric_limits<int16_t>::min() &&
+			 max_value <= numeric_limits<int16_t>::max()) {
 			return ECSACT_I16;
 		}
 		return ECSACT_I32;
@@ -676,8 +681,8 @@ static int32_t field_type_size(ecsact_field_type type) {
 	if(type.kind == ECSACT_TYPE_KIND_BUILTIN) {
 		base_size = builtin_type_size(type.type.builtin);
 	} else if(type.kind == ECSACT_TYPE_KIND_ENUM) {
-		base_size = builtin_type_size(ecsact_meta_enum_storage_type(type.type.enum_id)
-		);
+		base_size =
+			builtin_type_size(ecsact_meta_enum_storage_type(type.type.enum_id));
 	}
 
 	return base_size * type.length;
@@ -831,13 +836,13 @@ void ecsact_remove_child_system(
 
 	auto& parent_def = get_system_like(parent);
 	auto  itr = std::find_if(
-		parent_def.execution_order.begin(),
-		parent_def.execution_order.end(),
-		[&](const auto& entry) {
-			auto sys_id = std::get_if<ecsact_system_like_id>(&entry);
-			return sys_id && *sys_id == static_cast<ecsact_system_like_id>(child);
-		}
-	);
+    parent_def.execution_order.begin(),
+    parent_def.execution_order.end(),
+    [&](const auto& entry) {
+      auto sys_id = std::get_if<ecsact_system_like_id>(&entry);
+      return sys_id && *sys_id == static_cast<ecsact_system_like_id>(child);
+    }
+  );
 
 	child_def.parent_system_id = (ecsact_system_like_id)-1;
 	if(itr != parent_def.execution_order.end()) {
@@ -927,9 +932,10 @@ void ecsact_meta_get_dependencies(
 	int32_t*           out_dependency_count
 ) {
 	auto& pkg = package_defs.at(package_id);
-	auto  count =
-		std::min(max_dependency_count, static_cast<int32_t>(pkg.dependencies.size())
-		);
+	auto  count = std::min(
+    max_dependency_count,
+    static_cast<int32_t>(pkg.dependencies.size())
+  );
 
 	for(int i = 0; count > i; ++i) {
 		out_dependencies[i] = pkg.dependencies[i];
@@ -946,7 +952,8 @@ const char* ecsact_meta_decl_full_name(ecsact_decl_id id) {
 
 static bool collect_all_caps(
 	ecsact_system_like_id system_id,
-	std::unordered_map<ecsact_component_like_id, ecsact_system_capability>& out_caps
+	std::unordered_map<ecsact_component_like_id, ecsact_system_capability>&
+		out_caps
 ) {
 	auto& sys_def = get_system_like(system_id);
 	bool  independent = !sys_def.generates.empty() ||
@@ -972,7 +979,7 @@ static bool collect_all_caps(
 
 static std::optional<ecsact_system_like_id> calculate_execution_batches(
 	const std::vector<std::variant<ecsact_system_like_id, ecsact_cluster_id>>&
-		execution_order,
+																									 execution_order,
 	std::vector<std::vector<ecsact_system_like_id>>& out_batches
 ) {
 	out_batches.clear();
@@ -1010,46 +1017,50 @@ static std::optional<ecsact_system_like_id> calculate_execution_batches(
 		}
 	};
 
-	auto are_mutually_exclusive = [&](ecsact_system_like_id a, ecsact_system_like_id b) {
-		std::unordered_map<ecsact_component_like_id, ecsact_system_capability> a_caps;
-		std::unordered_map<ecsact_component_like_id, ecsact_system_capability> b_caps;
-		collect_all_caps(a, a_caps);
-		collect_all_caps(b, b_caps);
+	auto are_mutually_exclusive =
+		[&](ecsact_system_like_id a, ecsact_system_like_id b) {
+			std::unordered_map<ecsact_component_like_id, ecsact_system_capability>
+				a_caps;
+			std::unordered_map<ecsact_component_like_id, ecsact_system_capability>
+				b_caps;
+			collect_all_caps(a, a_caps);
+			collect_all_caps(b, b_caps);
 
-		for(auto const& [comp_id, a_cap] : a_caps) {
-			if(!b_caps.contains(comp_id)) {
-				continue;
-			}
-			auto b_cap = b_caps.at(comp_id);
+			for(auto const& [comp_id, a_cap] : a_caps) {
+				if(!b_caps.contains(comp_id)) {
+					continue;
+				}
+				auto b_cap = b_caps.at(comp_id);
 
-			auto is_inc = [](ecsact_system_capability cap) -> bool {
-				if((cap & ECSACT_SYS_CAP_INCLUDE) != 0) {
+				auto is_inc = [](ecsact_system_capability cap) -> bool {
+					if((cap & ECSACT_SYS_CAP_INCLUDE) != 0) {
+						return true;
+					}
+					if((cap & ECSACT_SYS_CAP_OPTIONAL) != 0) {
+						return false;
+					}
+					return (cap & (ECSACT_SYS_CAP_READONLY | ECSACT_SYS_CAP_WRITEONLY)) !=
+						0;
+				};
+
+				bool a_inc = is_inc(a_cap);
+				bool a_exc = (a_cap & ECSACT_SYS_CAP_EXCLUDE) != 0;
+				bool b_inc = is_inc(b_cap);
+				bool b_exc = (b_cap & ECSACT_SYS_CAP_EXCLUDE) != 0;
+
+				if((a_inc && b_exc) || (a_exc && b_inc)) {
 					return true;
 				}
-				if((cap & ECSACT_SYS_CAP_OPTIONAL) != 0) {
-					return false;
-				}
-				return (cap & (ECSACT_SYS_CAP_READONLY | ECSACT_SYS_CAP_WRITEONLY)) != 0;
-			};
-
-			bool a_inc = is_inc(a_cap);
-			bool a_exc = (a_cap & ECSACT_SYS_CAP_EXCLUDE) != 0;
-			bool b_inc = is_inc(b_cap);
-			bool b_exc = (b_cap & ECSACT_SYS_CAP_EXCLUDE) != 0;
-
-			if((a_inc && b_exc) || (a_exc && b_inc)) {
-				return true;
 			}
-		}
 
-		return false;
-	};
+			return false;
+		};
 
 	for(auto const& entry : execution_order) {
 		if(auto sys_id_ptr = std::get_if<ecsact_system_like_id>(&entry)) {
 			auto sys_id = *sys_id_ptr;
 			std::unordered_map<ecsact_component_like_id, ecsact_system_capability>
-				all_caps;
+					 all_caps;
 			bool independent = collect_all_caps(sys_id, all_caps);
 
 			bool conflict = independent;
@@ -1057,7 +1068,8 @@ static std::optional<ecsact_system_like_id> calculate_execution_batches(
 				for(auto const& [comp_id, cap] : all_caps) {
 					bool comp_conflict = false;
 					if(is_exclusive(cap)) {
-						if(batch_readers.contains(comp_id) || batch_writers.contains(comp_id)) {
+						if(batch_readers.contains(comp_id) ||
+							 batch_writers.contains(comp_id)) {
 							comp_conflict = true;
 						}
 					}
@@ -1106,7 +1118,7 @@ static std::optional<ecsact_system_like_id> calculate_execution_batches(
 			auto& cluster_def = cluster_defs.at(*cluster_id_ptr);
 			for(auto sys_id : cluster_def.systems) {
 				std::unordered_map<ecsact_component_like_id, ecsact_system_capability>
-					all_caps;
+						 all_caps;
 				bool independent = collect_all_caps(sys_id, all_caps);
 
 				bool conflict = independent;
@@ -1114,7 +1126,8 @@ static std::optional<ecsact_system_like_id> calculate_execution_batches(
 					for(auto const& [comp_id, cap] : all_caps) {
 						bool comp_conflict = false;
 						if(is_exclusive(cap)) {
-							if(batch_readers.contains(comp_id) || batch_writers.contains(comp_id)) {
+							if(batch_readers.contains(comp_id) ||
+								 batch_writers.contains(comp_id)) {
 								comp_conflict = true;
 							}
 						}
@@ -1443,7 +1456,9 @@ void ecsact_system_generates_unset_component(
 	sys_like_def.generates.at(generates_id).erase(component_id);
 }
 
-int32_t ecsact_meta_count_system_generates_ids(ecsact_system_like_id system_id) {
+int32_t ecsact_meta_count_system_generates_ids(
+	ecsact_system_like_id system_id
+) {
 	auto& sys_like_def = get_system_like(system_id);
 	return static_cast<int32_t>(sys_like_def.generates.size());
 }
@@ -1614,9 +1629,8 @@ void ecsact_add_system_to_cluster(
 	def.systems.push_back(system_id);
 
 	auto owner_pkg_id = owner_package_id(system_id);
-	auto parent_sys_id = ecsact_meta_get_parent_system_id(
-		static_cast<ecsact_system_id>(system_id)
-	);
+	auto parent_sys_id =
+		ecsact_meta_get_parent_system_id(static_cast<ecsact_system_id>(system_id));
 
 	auto& execution_order = (int32_t)parent_sys_id == -1
 		? package_defs.at(owner_pkg_id).execution_order

--- a/ecsact_interpret/parse-resolver-runtime/parse-resolver-runtime.cc
+++ b/ecsact_interpret/parse-resolver-runtime/parse-resolver-runtime.cc
@@ -1251,9 +1251,19 @@ static std::optional<ecsact_system_like_id> calculate_execution_batches(
 			}
 			auto b_cap = b_caps.at(comp_id);
 
-			bool a_inc = (a_cap & ECSACT_SYS_CAP_INCLUDE) != 0;
+			auto is_inc = [](ecsact_system_capability cap) -> bool {
+				if((cap & ECSACT_SYS_CAP_INCLUDE) != 0) {
+					return true;
+				}
+				if((cap & ECSACT_SYS_CAP_OPTIONAL) != 0) {
+					return false;
+				}
+				return (cap & (ECSACT_SYS_CAP_READONLY | ECSACT_SYS_CAP_WRITEONLY)) != 0;
+			};
+
+			bool a_inc = is_inc(a_cap);
 			bool a_exc = (a_cap & ECSACT_SYS_CAP_EXCLUDE) != 0;
-			bool b_inc = (b_cap & ECSACT_SYS_CAP_INCLUDE) != 0;
+			bool b_inc = is_inc(b_cap);
 			bool b_exc = (b_cap & ECSACT_SYS_CAP_EXCLUDE) != 0;
 
 			if((a_inc && b_exc) || (a_exc && b_inc)) {

--- a/ecsact_interpret/parse-resolver-runtime/parse-resolver-runtime.cc
+++ b/ecsact_interpret/parse-resolver-runtime/parse-resolver-runtime.cc
@@ -1198,7 +1198,7 @@ static bool collect_all_caps(
 	return independent;
 }
 
-static void calculate_execution_batches(
+static std::optional<ecsact_system_like_id> calculate_execution_batches(
 	const std::vector<ecsact_system_like_id>&        systems,
 	const std::vector<int32_t>&                      explicit_starts,
 	const std::vector<int32_t>&                      explicit_ends,
@@ -1239,27 +1239,73 @@ static void calculate_execution_batches(
 		}
 	};
 
+	auto are_mutually_exclusive = [&](ecsact_system_like_id a, ecsact_system_like_id b) {
+		std::unordered_map<ecsact_component_like_id, ecsact_system_capability> a_caps;
+		std::unordered_map<ecsact_component_like_id, ecsact_system_capability> b_caps;
+		collect_all_caps(a, a_caps);
+		collect_all_caps(b, b_caps);
+
+		for(auto const& [comp_id, a_cap] : a_caps) {
+			if(!b_caps.contains(comp_id)) {
+				continue;
+			}
+			auto b_cap = b_caps.at(comp_id);
+
+			bool a_inc = (a_cap & ECSACT_SYS_CAP_INCLUDE) != 0;
+			bool a_exc = (a_cap & ECSACT_SYS_CAP_EXCLUDE) != 0;
+			bool b_inc = (b_cap & ECSACT_SYS_CAP_INCLUDE) != 0;
+			bool b_exc = (b_cap & ECSACT_SYS_CAP_EXCLUDE) != 0;
+
+			if((a_inc && b_exc) || (a_exc && b_inc)) {
+				return true;
+			}
+		}
+
+		return false;
+	};
+
+	int32_t current_explicit_cluster_start = -1;
+
 	for(int32_t i = 0; static_cast<int32_t>(systems.size()) > i; ++i) {
 		auto sys_id = systems[i];
 		if(std::ranges::find(explicit_starts, i) != explicit_starts.end()) {
 			finalize_batch();
+			current_explicit_cluster_start = i;
 		}
 
 		std::unordered_map<ecsact_component_like_id, ecsact_system_capability>
-				 all_caps;
+			all_caps;
 		bool independent = collect_all_caps(sys_id, all_caps);
 
 		bool conflict = independent;
 		if(!conflict) {
 			for(auto const& [comp_id, cap] : all_caps) {
+				bool comp_conflict = false;
 				if(is_exclusive(cap)) {
 					if(batch_readers.contains(comp_id) || batch_writers.contains(comp_id)) {
-						conflict = true;
-						break;
+						comp_conflict = true;
 					}
 				}
 				if(is_reader(cap)) {
 					if(batch_writers.contains(comp_id)) {
+						comp_conflict = true;
+					}
+				}
+
+				if(comp_conflict) {
+					// Check if this system is mutually exclusive with EVERYTHING in the
+					// current batch that touched this component.
+					// For simplicity, we just check if it's mutually exclusive with
+					// ALL systems in the current batch.
+					bool all_exclusive = true;
+					for(auto other_sys_id : current_batch) {
+						if(!are_mutually_exclusive(sys_id, other_sys_id)) {
+							all_exclusive = false;
+							break;
+						}
+					}
+
+					if(!all_exclusive) {
 						conflict = true;
 						break;
 					}
@@ -1268,6 +1314,9 @@ static void calculate_execution_batches(
 		}
 
 		if(conflict) {
+			if(current_explicit_cluster_start != -1) {
+				return sys_id;
+			}
 			finalize_batch();
 		}
 
@@ -1282,15 +1331,26 @@ static void calculate_execution_batches(
 		}
 
 		if(independent) {
+			if(current_explicit_cluster_start != -1) {
+				// Independent systems always end their batch. If we're in an explicit
+				// cluster, then this system would be forced to be alone, which means
+				// the cluster is invalid if there are other systems.
+				// Wait - if the independent system is the FIRST in the cluster it's ok
+				if(current_explicit_cluster_start != i) {
+					return sys_id;
+				}
+			}
 			finalize_batch();
 		}
 
 		if(std::ranges::find(explicit_ends, i + 1) != explicit_ends.end()) {
 			finalize_batch();
+			current_explicit_cluster_start = -1;
 		}
 	}
 
 	finalize_batch();
+	return std::nullopt;
 }
 
 int32_t ecsact_meta_count_execution_batches(ecsact_package_id package_id) {
@@ -1411,6 +1471,60 @@ void ecsact_meta_get_system_execution_batch(
 	if(out_systems_count != nullptr) {
 		*out_systems_count = static_cast<int32_t>(batch.size());
 	}
+}
+
+ecsact_system_like_id ecsact_meta_check_execution_batches(
+	ecsact_package_id package_id
+) {
+	auto& pkg = package_defs.at(package_id);
+	std::vector<ecsact_system_like_id> all_systems;
+	for(auto dep_id : pkg.dependencies) {
+		auto& dep_pkg = package_defs.at(dep_id);
+		for(auto sys_id : dep_pkg.top_level_systems) {
+			all_systems.push_back(sys_id);
+		}
+	}
+	for(auto sys_id : pkg.top_level_systems) {
+		all_systems.push_back(sys_id);
+	}
+
+	if(all_systems.empty()) {
+		return (ecsact_system_like_id)-1;
+	}
+
+	std::vector<std::vector<ecsact_system_like_id>> batches;
+	auto result = calculate_execution_batches(
+		all_systems,
+		pkg.explicit_cluster_starts,
+		pkg.explicit_cluster_ends,
+		batches
+	);
+
+	return result.value_or((ecsact_system_like_id)-1);
+}
+
+ecsact_system_like_id ecsact_meta_check_system_execution_batches(
+	ecsact_system_like_id system_id
+) {
+	auto& sys_def = get_system_like(system_id);
+	if(sys_def.nested_systems.empty()) {
+		return (ecsact_system_like_id)-1;
+	}
+
+	std::vector<ecsact_system_like_id> nested_systems;
+	for(auto id : sys_def.nested_systems) {
+		nested_systems.push_back(ecsact_id_cast<ecsact_system_like_id>(id));
+	}
+
+	std::vector<std::vector<ecsact_system_like_id>> batches;
+	auto result = calculate_execution_batches(
+		nested_systems,
+		sys_def.explicit_cluster_starts,
+		sys_def.explicit_cluster_ends,
+		batches
+	);
+
+	return result.value_or((ecsact_system_like_id)-1);
 }
 
 bool ecsact_meta_is_system(ecsact_system_like_id system_id) {

--- a/ecsact_interpret/parse-resolver-runtime/parse-resolver-runtime.cc
+++ b/ecsact_interpret/parse-resolver-runtime/parse-resolver-runtime.cc
@@ -17,37 +17,43 @@
 
 using ecsact::interpret::details::trigger_on_destroy;
 
-struct field {
-	std::string       name;
-	ecsact_field_type type;
-};
+template<typename T, typename... Ts>
+struct is_any : std::disjunction<std::is_same<T, Ts>...> {};
 
-class composite {
-	int32_t _last_field_id = -1;
+template<typename T, typename... Ts>
+inline constexpr bool is_any_v = is_any<T, Ts...>::value;
 
-public:
+template<typename T>
+static std::atomic<int32_t> last_id_val = 0;
+
+template<typename T>
+static T next_id() {
+	return static_cast<T>(++last_id_val<int32_t>);
+}
+
+struct composite {
+	struct field {
+		std::string       name;
+		ecsact_field_type type;
+	};
+
 	std::map<ecsact_field_id, field> fields;
 
 	inline ecsact_field_id next_field_id() {
-		return static_cast<ecsact_field_id>(++_last_field_id);
+		return static_cast<ecsact_field_id>(fields.size());
 	}
 };
 
-struct component_like : composite {};
-
-struct comp_def : component_like {
+struct comp_def : composite {
 	std::string           name;
 	ecsact_component_type comp_type;
 };
 
-struct trans_def : component_like {
+struct trans_def : composite {
 	std::string name;
 };
 
 struct system_like {
-	using cap_comp_map_t =
-		std::unordered_map<ecsact_component_like_id, ecsact_system_capability>;
-
 	struct cap_entry {
 		ecsact_system_capability cap;
 	};
@@ -75,13 +81,17 @@ struct system_like {
 	ecsact_system_like_id parent_system_id = (ecsact_system_like_id)-1;
 
 	/** in execution order */
-	std::vector<ecsact_system_id> nested_systems;
+	std::vector<std::variant<ecsact_system_like_id, ecsact_cluster_id>>
+		execution_order;
 
 	ecsact_parallel_execution parallel_execution = {};
 
 	std::vector<std::vector<ecsact_system_like_id>> execution_batches;
-	std::vector<int32_t>                            explicit_cluster_starts;
-	std::vector<int32_t>                            explicit_cluster_ends;
+};
+
+struct cluster_def {
+	std::string                        name;
+	std::vector<ecsact_system_like_id> systems;
 };
 
 struct action_def : composite, system_like {
@@ -125,11 +135,10 @@ struct package_def {
 	std::vector<ecsact_enum_id>      enums;
 
 	/** in execution order */
-	std::vector<ecsact_system_like_id> top_level_systems;
+	std::vector<std::variant<ecsact_system_like_id, ecsact_cluster_id>>
+		execution_order;
 
 	std::vector<std::vector<ecsact_system_like_id>> execution_batches;
-	std::vector<int32_t>                            explicit_cluster_starts;
-	std::vector<int32_t>                            explicit_cluster_ends;
 };
 
 static std::atomic_int32_t                                   last_id = 0;
@@ -141,6 +150,7 @@ static std::unordered_map<ecsact_transient_id, trans_def>    trans_defs;
 static std::unordered_map<ecsact_system_id, system_def>      sys_defs;
 static std::unordered_map<ecsact_action_id, action_def>      act_defs;
 static std::unordered_map<ecsact_enum_id, enum_def>          enum_defs;
+static std::unordered_map<ecsact_cluster_id, cluster_def>    cluster_defs;
 static std::optional<ecsact_package_id>                      main_package_id;
 
 template<typename T>
@@ -152,51 +162,33 @@ static ecsact_package_id owner_package_id(T id) {
 	return def_owner_map.at(decl_id);
 }
 
-template<typename Callback>
-void visit_each_def_collection(Callback&& callback) {
-	callback(comp_defs);
-	callback(trans_defs);
-	callback(sys_defs);
-	callback(act_defs);
-}
-
-template<typename T>
-static void set_package_owner(T id, ecsact_package_id owner) {
-	assert(package_defs.contains(owner));
-	def_owner_map[ecsact_id_cast<ecsact_decl_id>(id)] = owner;
-}
-
-static composite& get_composite(ecsact_composite_id id) {
-	if(comp_defs.contains((ecsact_component_id)id)) {
-		return comp_defs.at((ecsact_component_id)id);
-	}
-
-	if(trans_defs.contains((ecsact_transient_id)id)) {
-		return trans_defs.at((ecsact_transient_id)id);
-	}
-
-	if(act_defs.contains((ecsact_action_id)id)) {
-		return act_defs.at((ecsact_action_id)id);
-	}
-
-	throw std::invalid_argument("Invalid composite ID");
+static void set_package_owner(ecsact_decl_id id, ecsact_package_id owner) {
+	def_owner_map[id] = owner;
 }
 
 static system_like& get_system_like(ecsact_system_like_id id) {
-	if(sys_defs.contains((ecsact_system_id)id)) {
-		return sys_defs.at((ecsact_system_id)id);
+	if(sys_defs.contains(static_cast<ecsact_system_id>(id))) {
+		return sys_defs.at(static_cast<ecsact_system_id>(id));
+	}
+	if(act_defs.contains(static_cast<ecsact_action_id>(id))) {
+		return act_defs.at(static_cast<ecsact_action_id>(id));
 	}
 
-	if(act_defs.contains((ecsact_action_id)id)) {
-		return act_defs.at((ecsact_action_id)id);
-	}
-
-	throw std::invalid_argument("Invalid system-like ID");
+	throw std::runtime_error("Invalid system_like_id");
 }
 
-template<typename T>
-static T next_id() {
-	return static_cast<T>(last_id++);
+static composite& get_composite(ecsact_composite_id id) {
+	if(comp_defs.contains(static_cast<ecsact_component_id>(id))) {
+		return comp_defs.at(static_cast<ecsact_component_id>(id));
+	}
+	if(trans_defs.contains(static_cast<ecsact_transient_id>(id))) {
+		return trans_defs.at(static_cast<ecsact_transient_id>(id));
+	}
+	if(act_defs.contains(static_cast<ecsact_action_id>(id))) {
+		return act_defs.at(static_cast<ecsact_action_id>(id));
+	}
+
+	throw std::runtime_error("Invalid composite_id");
 }
 
 ecsact_package_id ecsact_create_package(
@@ -204,48 +196,51 @@ ecsact_package_id ecsact_create_package(
 	const char* package_name,
 	int32_t     package_name_len
 ) {
-	auto  pkg_id = next_id<ecsact_package_id>();
-	auto& pkg = package_defs[pkg_id];
-	pkg.name = std::string_view(package_name, package_name_len);
+	auto id = next_id<ecsact_package_id>();
+	auto name = std::string(package_name, package_name_len);
+	package_defs[id] = {
+		.name = name,
+		.main = main_package,
+	};
+
 	if(main_package) {
-		main_package_id = pkg_id;
+		main_package_id = id;
 	}
-	return pkg_id;
+
+	return id;
 }
 
-ecsact_package_id ecsact_meta_main_package() {
-	if(main_package_id) {
-		return *main_package_id;
-	}
+void ecsact_add_dependency(ecsact_package_id target, ecsact_package_id dependency) {
+	package_defs.at(target).dependencies.push_back(dependency);
+}
 
-	return (ecsact_package_id)-1;
+void ecsact_remove_dependency(
+	ecsact_package_id target,
+	ecsact_package_id dependency
+) {
+	auto& deps = package_defs.at(target).dependencies;
+	deps.erase(std::remove(deps.begin(), deps.end(), dependency), deps.end());
 }
 
 void ecsact_destroy_package(ecsact_package_id package_id) {
-	auto itr = package_defs.find(package_id);
-	if(itr == package_defs.end()) {
-		return;
+	if(main_package_id == package_id) {
+		main_package_id = std::nullopt;
 	}
 
-	package_defs.erase(itr);
-
-	visit_each_def_collection([&](auto& defs) {
-		for(auto itr = defs.begin(); itr != defs.end();) {
-			if(owner_package_id(itr->first) != package_id) {
-				++itr;
-			} else {
-				trigger_on_destroy(itr->first);
-				itr = defs.erase(itr);
-			}
-		}
-	});
-
+	package_defs.erase(package_id);
 	auto owner_itr = def_owner_map.begin();
 	while(owner_itr != def_owner_map.end()) {
-		if(owner_itr->second != package_id) {
-			++owner_itr;
-		} else {
+		if(owner_itr->second == package_id) {
+			auto decl_id = owner_itr->first;
+			full_names.erase(decl_id);
+			comp_defs.erase(static_cast<ecsact_component_id>(decl_id));
+			trans_defs.erase(static_cast<ecsact_transient_id>(decl_id));
+			sys_defs.erase(static_cast<ecsact_system_id>(decl_id));
+			act_defs.erase(static_cast<ecsact_action_id>(decl_id));
+			enum_defs.erase(static_cast<ecsact_enum_id>(decl_id));
 			owner_itr = def_owner_map.erase(owner_itr);
+		} else {
+			++owner_itr;
 		}
 	}
 
@@ -291,9 +286,9 @@ ecsact_component_id ecsact_create_component(
 	auto  comp_id = next_id<ecsact_component_id>();
 	auto  decl_id = ecsact_id_cast<ecsact_decl_id>(comp_id);
 	pkg_def.components.push_back(comp_id);
-	set_package_owner(comp_id, owner);
+	set_package_owner(decl_id, owner);
 	auto& def = comp_defs[comp_id];
-	def.name = std::string_view(component_name, component_name_len);
+	def.name = std::string(component_name, component_name_len);
 	def.comp_type = ECSACT_COMPONENT_TYPE_NONE;
 	full_names[decl_id] = pkg_def.name + "." + def.name;
 
@@ -309,9 +304,9 @@ ecsact_transient_id ecsact_create_transient(
 	auto  trans_id = next_id<ecsact_transient_id>();
 	auto  decl_id = ecsact_id_cast<ecsact_decl_id>(trans_id);
 	pkg_def.transients.push_back(trans_id);
-	set_package_owner(trans_id, owner);
+	set_package_owner(decl_id, owner);
 	auto& def = trans_defs[trans_id];
-	def.name = std::string_view(transient_name, transient_name_len);
+	def.name = std::string(transient_name, transient_name_len);
 	full_names[decl_id] = pkg_def.name + "." + def.name;
 
 	return trans_id;
@@ -325,12 +320,12 @@ ecsact_system_id ecsact_create_system(
 	auto&      pkg_def = package_defs.at(owner);
 	const auto sys_id = next_id<ecsact_system_id>();
 	const auto decl_id = ecsact_id_cast<ecsact_decl_id>(sys_id);
-	const auto sys_like_id = ecsact_id_cast<ecsact_system_like_id>(sys_id);
+	const auto sys_like_id = static_cast<ecsact_system_like_id>(sys_id);
 	pkg_def.systems.push_back(sys_id);
-	pkg_def.top_level_systems.push_back(sys_like_id);
-	set_package_owner(sys_id, owner);
+	pkg_def.execution_order.push_back(sys_like_id);
+	set_package_owner(decl_id, owner);
 	auto& def = sys_defs[sys_id];
-	def.name = std::string_view(system_name, system_name_len);
+	def.name = std::string(system_name, system_name_len);
 	if(def.name.empty()) {
 		full_names[decl_id] = "";
 	} else {
@@ -348,12 +343,12 @@ ecsact_action_id ecsact_create_action(
 	auto&      pkg_def = package_defs.at(owner);
 	const auto act_id = next_id<ecsact_action_id>();
 	const auto decl_id = ecsact_id_cast<ecsact_decl_id>(act_id);
-	const auto sys_like_id = ecsact_id_cast<ecsact_system_like_id>(act_id);
+	const auto sys_like_id = static_cast<ecsact_system_like_id>(act_id);
 	pkg_def.actions.push_back(act_id);
-	pkg_def.top_level_systems.push_back(sys_like_id);
-	set_package_owner(act_id, owner);
+	pkg_def.execution_order.push_back(sys_like_id);
+	set_package_owner(decl_id, owner);
 	auto& def = act_defs[act_id];
-	def.name = std::string_view(action_name, action_name_len);
+	def.name = std::string(action_name, action_name_len);
 	full_names[decl_id] = pkg_def.name + "." + def.name;
 
 	return act_id;
@@ -367,8 +362,9 @@ ecsact_enum_id ecsact_create_enum(
 	auto& pkg_def = package_defs.at(owner);
 	auto  enum_id = next_id<ecsact_enum_id>();
 	auto& def = enum_defs[enum_id];
-	def.name = std::string_view(enum_name, enum_name_len);
+	def.name = std::string(enum_name, enum_name_len);
 	pkg_def.enums.push_back(enum_id);
+	set_package_owner(ecsact_id_cast<ecsact_decl_id>(enum_id), owner);
 
 	return enum_id;
 }
@@ -399,6 +395,7 @@ void ecsact_meta_get_system_ids(
 	int32_t*          out_system_count
 ) {
 	auto& pkg_def = package_defs.at(package_id);
+
 	auto  itr = pkg_def.systems.begin();
 	for(int32_t i = 0; max_system_count > i && itr != pkg_def.systems.end();
 			++i) {
@@ -454,7 +451,11 @@ const char* ecsact_meta_transient_name(ecsact_transient_id trans) {
 }
 
 const char* ecsact_meta_system_name(ecsact_system_id sys_id) {
-	return sys_defs.at(sys_id).name.c_str();
+	auto& name = sys_defs.at(sys_id).name;
+	if(name.empty()) {
+		return "";
+	}
+	return name.c_str();
 }
 
 const char* ecsact_meta_action_name(ecsact_action_id act_id) {
@@ -501,22 +502,22 @@ ecsact_builtin_type ecsact_meta_enum_storage_type(ecsact_enum_id enum_id) {
 		}
 	}
 
-	if(min_value < 0) {
-		if(max_value > numeric_limits<int16_t>::max()) {
-			return ECSACT_I32;
+	if(min_value >= 0) {
+		if(max_value <= numeric_limits<uint8_t>::max()) {
+			return ECSACT_U8;
 		}
-		if(max_value > numeric_limits<int8_t>::max()) {
-			return ECSACT_I16;
-		}
-		return ECSACT_I8;
-	} else {
-		if(max_value > numeric_limits<uint16_t>::max()) {
-			return ECSACT_U32;
-		}
-		if(max_value > numeric_limits<uint8_t>::max()) {
+		if(max_value <= numeric_limits<uint16_t>::max()) {
 			return ECSACT_U16;
 		}
-		return ECSACT_U8;
+		return ECSACT_U32;
+	} else {
+		if(min_value >= numeric_limits<int8_t>::min() && max_value <= numeric_limits<int8_t>::max()) {
+			return ECSACT_I8;
+		}
+		if(min_value >= numeric_limits<int16_t>::min() && max_value <= numeric_limits<int16_t>::max()) {
+			return ECSACT_I16;
+		}
+		return ECSACT_I32;
 	}
 }
 
@@ -527,37 +528,48 @@ int32_t ecsact_meta_count_enum_values(ecsact_enum_id enum_id) {
 
 void ecsact_meta_get_enum_value_ids(
 	ecsact_enum_id        enum_id,
-	int32_t               max_enum_value_ids,
+	int32_t               max_enum_value_count,
 	ecsact_enum_value_id* out_enum_value_ids,
-	int32_t*              out_enum_values_count
+	int32_t*              out_enum_value_count
 ) {
 	auto& def = enum_defs.at(enum_id);
 
 	auto itr = def.enum_values.begin();
-	for(int i = 0; max_enum_value_ids > i && itr != def.enum_values.end(); ++i) {
+	for(int i = 0; max_enum_value_count > i && itr != def.enum_values.end();
+			++i) {
 		out_enum_value_ids[i] = itr->first;
 		++itr;
 	}
 
-	if(out_enum_values_count) {
-		*out_enum_values_count = static_cast<int32_t>(def.enum_values.size());
+	if(out_enum_value_count) {
+		*out_enum_value_count = static_cast<int32_t>(def.enum_values.size());
 	}
+}
+
+const char* ecsact_meta_enum_name(ecsact_enum_id enum_id) {
+	return enum_defs.at(enum_id).name.c_str();
 }
 
 const char* ecsact_meta_enum_value_name(
 	ecsact_enum_id       enum_id,
 	ecsact_enum_value_id enum_value_id
 ) {
-	auto& def = enum_defs.at(enum_id);
-	return def.enum_values.at(enum_value_id).name.c_str();
+	return enum_defs.at(enum_id).enum_values.at(enum_value_id).name.c_str();
 }
 
 int32_t ecsact_meta_enum_value(
 	ecsact_enum_id       enum_id,
 	ecsact_enum_value_id enum_value_id
 ) {
-	auto& def = enum_defs.at(enum_id);
-	return def.enum_values.at(enum_value_id).value;
+	return enum_defs.at(enum_id).enum_values.at(enum_value_id).value;
+}
+
+const char* ecsact_meta_registry_name(ecsact_registry_id) {
+	return "";
+}
+
+ecsact_package_id ecsact_meta_main_package() {
+	return main_package_id.value_or((ecsact_package_id)-1);
 }
 
 void ecsact_meta_get_component_ids(
@@ -567,14 +579,15 @@ void ecsact_meta_get_component_ids(
 	int32_t*             out_component_count
 ) {
 	auto& pkg_def = package_defs.at(package_id);
-	auto  itr = pkg_def.components.begin();
-	for(int32_t i = 0; max_component_count > i && itr != pkg_def.components.end();
+
+	auto itr = pkg_def.components.begin();
+	for(int i = 0; max_component_count > i && itr != pkg_def.components.end();
 			++i) {
 		out_component_ids[i] = *itr;
 		++itr;
 	}
 
-	if(out_component_count != nullptr) {
+	if(out_component_count) {
 		*out_component_count = static_cast<int32_t>(pkg_def.components.size());
 	}
 }
@@ -586,33 +599,17 @@ void ecsact_meta_get_transient_ids(
 	int32_t*             out_transient_count
 ) {
 	auto& pkg_def = package_defs.at(package_id);
-	auto  itr = pkg_def.transients.begin();
-	for(int32_t i = 0; max_transient_count > i && itr != pkg_def.transients.end();
+
+	auto itr = pkg_def.transients.begin();
+	for(int i = 0; max_transient_count > i && itr != pkg_def.transients.end();
 			++i) {
 		out_transient_ids[i] = *itr;
 		++itr;
 	}
 
-	if(out_transient_count != nullptr) {
+	if(out_transient_count) {
 		*out_transient_count = static_cast<int32_t>(pkg_def.transients.size());
 	}
-}
-
-ecsact_field_id ecsact_add_field(
-	ecsact_composite_id composite_id,
-	ecsact_field_type   field_type,
-	const char*         field_name,
-	int32_t             field_name_len
-) {
-	auto& def = get_composite(composite_id);
-	auto  field_id = def.next_field_id();
-
-	def.fields[field_id] = {
-		.name = std::string(field_name, field_name_len),
-		.type = field_type,
-	};
-
-	return field_id;
 }
 
 int32_t ecsact_meta_count_fields(ecsact_composite_id composite_id) {
@@ -624,18 +621,18 @@ void ecsact_meta_get_field_ids(
 	ecsact_composite_id composite_id,
 	int32_t             max_field_count,
 	ecsact_field_id*    out_field_ids,
-	int32_t*            out_field_ids_count
+	int32_t*            out_field_count
 ) {
 	auto& def = get_composite(composite_id);
 
 	auto itr = def.fields.begin();
-	for(int32_t i = 0; max_field_count > i && itr != def.fields.end(); ++i) {
+	for(int i = 0; max_field_count > i && itr != def.fields.end(); ++i) {
 		out_field_ids[i] = itr->first;
 		++itr;
 	}
 
-	if(out_field_ids_count != nullptr) {
-		*out_field_ids_count = static_cast<int32_t>(def.fields.size());
+	if(out_field_count) {
+		*out_field_count = static_cast<int32_t>(def.fields.size());
 	}
 }
 
@@ -652,14 +649,13 @@ ecsact_field_type ecsact_meta_field_type(
 	ecsact_field_id     field_id
 ) {
 	auto& def = get_composite(composite_id);
-	auto& field = def.fields.at(field_id);
-
-	return field.type;
+	return def.fields.at(field_id).type;
 }
 
-static auto builtin_type_size(ecsact_builtin_type builtin_type) {
-	switch(builtin_type) {
+static int32_t builtin_type_size(ecsact_builtin_type type) {
+	switch(type) {
 		case ECSACT_BOOL:
+			return 1;
 		case ECSACT_I8:
 		case ECSACT_U8:
 			return 1;
@@ -669,35 +665,19 @@ static auto builtin_type_size(ecsact_builtin_type builtin_type) {
 		case ECSACT_I32:
 		case ECSACT_U32:
 		case ECSACT_F32:
-			return 4;
-		case ECSACT_I64:
-		case ECSACT_U64:
-		case ECSACT_F64:
-			return 8;
 		case ECSACT_ENTITY_TYPE:
 			return 4;
 	}
+	return 0;
 }
 
-static auto enum_type_size(ecsact_enum_id enum_id) {
-	return builtin_type_size(ecsact_meta_enum_storage_type(enum_id));
-}
-
-static auto field_type_size(ecsact_field_type type) -> int32_t {
-	auto base_size = 0;
-	switch(type.kind) {
-		case ECSACT_TYPE_KIND_BUILTIN:
-			base_size = builtin_type_size(type.type.builtin);
-			break;
-		case ECSACT_TYPE_KIND_ENUM:
-			base_size = enum_type_size(type.type.enum_id);
-			break;
-		case ECSACT_TYPE_KIND_FIELD_INDEX:
-			base_size = field_type_size(ecsact_meta_field_type(
-				type.type.field_index.composite_id,
-				type.type.field_index.field_id
-			));
-			break;
+static int32_t field_type_size(ecsact_field_type type) {
+	int32_t base_size = 0;
+	if(type.kind == ECSACT_TYPE_KIND_BUILTIN) {
+		base_size = builtin_type_size(type.type.builtin);
+	} else if(type.kind == ECSACT_TYPE_KIND_ENUM) {
+		base_size = builtin_type_size(ecsact_meta_enum_storage_type(type.type.enum_id)
+		);
 	}
 
 	return base_size * type.length;
@@ -707,41 +687,107 @@ int32_t ecsact_meta_field_offset(
 	ecsact_composite_id composite_id,
 	ecsact_field_id     field_id
 ) {
-	auto& def = get_composite(composite_id);
-	auto  largest_field_size = 0;
-	auto  current_field_index = 0;
-	auto  field_index = 0;
-	for(auto& field : def.fields) {
-		auto size = field_type_size(field.second.type);
-		if(size > largest_field_size) {
-			largest_field_size = size;
+	auto&   def = get_composite(composite_id);
+	int32_t offset = 0;
+	for(auto const& [id, field] : def.fields) {
+		if(id == field_id) {
+			return offset;
 		}
-
-		if(field.first == field_id) {
-			field_index = current_field_index;
-		}
-
-		current_field_index += 1;
+		offset += field_type_size(field.type);
 	}
+	return -1;
+}
 
-	return static_cast<int32_t>(field_index * largest_field_size);
+ecsact_field_id ecsact_add_field(
+	ecsact_composite_id composite_id,
+	ecsact_field_type   field_type,
+	const char*         field_name,
+	int32_t             field_name_len
+) {
+	auto& def = get_composite(composite_id);
+	auto  id = def.next_field_id();
+	auto& field = def.fields[id];
+	field.name = std::string(field_name, field_name_len);
+	field.type = field_type;
+	return id;
+}
+
+void ecsact_remove_field(
+	ecsact_composite_id composite_id,
+	ecsact_field_id     field_id
+) {
+	auto& def = get_composite(composite_id);
+	def.fields.erase(field_id);
+}
+
+void ecsact_destroy_component(ecsact_component_id component_id) {
+	auto decl_id = ecsact_id_cast<ecsact_decl_id>(component_id);
+	auto owner = owner_package_id(component_id);
+	if((int32_t)owner != -1) {
+		auto& pkg = package_defs.at(owner);
+		pkg.components.erase(
+			std::remove(pkg.components.begin(), pkg.components.end(), component_id),
+			pkg.components.end()
+		);
+	}
+	comp_defs.erase(component_id);
+	def_owner_map.erase(decl_id);
+	full_names.erase(decl_id);
+}
+
+void ecsact_destroy_transient(ecsact_transient_id transient_id) {
+	auto decl_id = ecsact_id_cast<ecsact_decl_id>(transient_id);
+	auto owner = owner_package_id(transient_id);
+	if((int32_t)owner != -1) {
+		auto& pkg = package_defs.at(owner);
+		pkg.transients.erase(
+			std::remove(pkg.transients.begin(), pkg.transients.end(), transient_id),
+			pkg.transients.end()
+		);
+	}
+	trans_defs.erase(transient_id);
+	def_owner_map.erase(decl_id);
+	full_names.erase(decl_id);
+}
+
+void ecsact_destroy_enum(ecsact_enum_id enum_id) {
+	auto decl_id = ecsact_id_cast<ecsact_decl_id>(enum_id);
+	auto owner = owner_package_id(enum_id);
+	if((int32_t)owner != -1) {
+		auto& pkg = package_defs.at(owner);
+		pkg.enums.erase(
+			std::remove(pkg.enums.begin(), pkg.enums.end(), enum_id),
+			pkg.enums.end()
+		);
+	}
+	enum_defs.erase(enum_id);
+	def_owner_map.erase(decl_id);
+	full_names.erase(decl_id);
+}
+
+void ecsact_remove_enum_value(
+	ecsact_enum_id       enum_id,
+	ecsact_enum_value_id value_id
+) {
+	auto& def = enum_defs.at(enum_id);
+	def.enum_values.erase(value_id);
 }
 
 void ecsact_set_system_capability(
-	ecsact_system_like_id    sys_id,
-	ecsact_component_like_id comp_like_id,
-	ecsact_system_capability cap
+	ecsact_system_like_id    system_id,
+	ecsact_component_like_id component_id,
+	ecsact_system_capability capability
 ) {
-	auto& def = get_system_like(sys_id);
-	def.caps[comp_like_id].cap = cap;
+	auto& def = get_system_like(system_id);
+	def.caps[component_id] = {capability};
 }
 
 void ecsact_unset_system_capability(
-	ecsact_system_like_id    sys_id,
-	ecsact_component_like_id comp_like_id
+	ecsact_system_like_id    system_id,
+	ecsact_component_like_id component_id
 ) {
-	auto& def = get_system_like(sys_id);
-	def.caps.erase(comp_like_id);
+	auto& def = get_system_like(system_id);
+	def.caps.erase(component_id);
 }
 
 int32_t ecsact_meta_system_capabilities_count(ecsact_system_like_id system_id) {
@@ -784,19 +830,22 @@ void ecsact_remove_child_system(
 	}
 
 	auto& parent_def = get_system_like(parent);
-	auto  itr = std::find(
-    parent_def.nested_systems.begin(),
-    parent_def.nested_systems.end(),
-    child
-  );
+	auto  itr = std::find_if(
+		parent_def.execution_order.begin(),
+		parent_def.execution_order.end(),
+		[&](const auto& entry) {
+			auto sys_id = std::get_if<ecsact_system_like_id>(&entry);
+			return sys_id && *sys_id == static_cast<ecsact_system_like_id>(child);
+		}
+	);
 
 	child_def.parent_system_id = (ecsact_system_like_id)-1;
-	if(itr != parent_def.nested_systems.end()) {
+	if(itr != parent_def.execution_order.end()) {
 		auto& pkg_def = package_defs.at(owner_package_id(parent));
-		pkg_def.top_level_systems.push_back(
-			ecsact_id_cast<ecsact_system_like_id>(*itr)
+		pkg_def.execution_order.push_back(
+			static_cast<ecsact_system_like_id>(child)
 		);
-		parent_def.nested_systems.erase(itr);
+		parent_def.execution_order.erase(itr);
 	}
 
 	if(!child_def.name.empty()) {
@@ -819,16 +868,21 @@ void ecsact_add_child_system(
 	}
 
 	child_def.parent_system_id = parent;
-	parent_def.nested_systems.push_back(child);
-
-	auto iter = std::find(
-		pkg_def.top_level_systems.begin(),
-		pkg_def.top_level_systems.end(),
-		ecsact_id_cast<ecsact_system_like_id>(child)
+	parent_def.execution_order.push_back(
+		static_cast<ecsact_system_like_id>(child)
 	);
 
-	if(iter != pkg_def.top_level_systems.end()) {
-		pkg_def.top_level_systems.erase(iter);
+	auto iter = std::find_if(
+		pkg_def.execution_order.begin(),
+		pkg_def.execution_order.end(),
+		[&](const auto& entry) {
+			auto sys_id = std::get_if<ecsact_system_like_id>(&entry);
+			return sys_id && *sys_id == static_cast<ecsact_system_like_id>(child);
+		}
+	);
+
+	if(iter != pkg_def.execution_order.end()) {
+		pkg_def.execution_order.erase(iter);
 	}
 
 	if(!child_def.name.empty()) {
@@ -862,48 +916,27 @@ const char* ecsact_meta_package_file_path(ecsact_package_id package_id) {
 	return def.source_file_path.c_str();
 }
 
-const char* ecsact_meta_enum_name(ecsact_enum_id enum_id) {
-	auto& def = enum_defs.at(enum_id);
-	return def.name.c_str();
-}
-
-const char* ecsact_meta_registry_name(ecsact_registry_id) {
-	// No registries in parse resolver tuneim
-	return "";
-}
-
 int32_t ecsact_meta_count_dependencies(ecsact_package_id package_id) {
-	auto& pkg_def = package_defs.at(package_id);
-	return static_cast<int32_t>(pkg_def.dependencies.size());
+	return static_cast<int32_t>(package_defs.at(package_id).dependencies.size());
 }
 
 void ecsact_meta_get_dependencies(
 	ecsact_package_id  package_id,
 	int32_t            max_dependency_count,
-	ecsact_package_id* out_package_ids,
-	int32_t*           out_dependencies_count
+	ecsact_package_id* out_dependencies,
+	int32_t*           out_dependency_count
 ) {
-	auto& pkg_def = package_defs.at(package_id);
-	auto  itr = pkg_def.dependencies.begin();
-	for(int i = 0; max_dependency_count > i; ++i, ++itr) {
-		if(itr == pkg_def.dependencies.end()) {
-			break;
-		}
-		out_package_ids[i] = *itr;
+	auto& pkg = package_defs.at(package_id);
+	auto  count =
+		std::min(max_dependency_count, static_cast<int32_t>(pkg.dependencies.size())
+		);
+
+	for(int i = 0; count > i; ++i) {
+		out_dependencies[i] = pkg.dependencies[i];
 	}
 
-	if(out_dependencies_count) {
-		*out_dependencies_count = static_cast<int32_t>(pkg_def.dependencies.size());
-	}
-}
-
-void ecsact_add_dependency(
-	ecsact_package_id target,
-	ecsact_package_id dependency
-) {
-	auto& tgt_pkg_def = package_defs.at(target);
-	if(package_defs.contains(dependency)) {
-		tgt_pkg_def.dependencies.push_back(dependency);
+	if(out_dependency_count != nullptr) {
+		*out_dependency_count = static_cast<int32_t>(pkg.dependencies.size());
 	}
 }
 
@@ -911,269 +944,9 @@ const char* ecsact_meta_decl_full_name(ecsact_decl_id id) {
 	return full_names.at(id).c_str();
 }
 
-int32_t ecsact_meta_count_child_systems(ecsact_system_like_id system_id) {
-	auto& def = get_system_like(system_id);
-	return static_cast<int32_t>(def.nested_systems.size());
-}
-
-void ecsact_meta_get_child_system_ids(
-	ecsact_system_like_id system_id,
-	int32_t               max_child_system_ids_count,
-	ecsact_system_id*     out_child_system_ids,
-	int32_t*              out_child_system_count
-) {
-	auto& def = get_system_like(system_id);
-
-	auto itr = def.nested_systems.begin();
-	for(int i = 0; max_child_system_ids_count > i; ++i, ++itr) {
-		if(itr == def.nested_systems.end()) {
-			break;
-		}
-		out_child_system_ids[i] = *itr;
-	}
-
-	if(out_child_system_count) {
-		*out_child_system_count = static_cast<int32_t>(def.nested_systems.size());
-	}
-}
-
-ecsact_system_like_id ecsact_meta_get_parent_system_id(
-	ecsact_system_id child_system_id
-) {
-	auto& def =
-		get_system_like(ecsact_id_cast<ecsact_system_like_id>(child_system_id));
-	return def.parent_system_id;
-}
-
-int32_t ecsact_meta_count_top_level_systems(ecsact_package_id package_id) {
-	auto& pkg_def = package_defs.at(package_id);
-	return static_cast<int32_t>(pkg_def.top_level_systems.size());
-}
-
-void ecsact_meta_get_top_level_systems(
-	ecsact_package_id      package_id,
-	int32_t                max_systems_count,
-	ecsact_system_like_id* out_systems,
-	int32_t*               out_systems_count
-) {
-	auto& pkg_def = package_defs.at(package_id);
-
-	auto itr = pkg_def.top_level_systems.begin();
-	for(int i = 0; max_systems_count > i; ++i, ++itr) {
-		if(itr == pkg_def.top_level_systems.end()) {
-			break;
-		}
-		out_systems[i] = *itr;
-	}
-
-	if(out_systems_count != nullptr) {
-		*out_systems_count = static_cast<int32_t>(pkg_def.top_level_systems.size());
-	}
-}
-
-ecsact_system_generates_id ecsact_add_system_generates(
-	ecsact_system_like_id system_id
-) {
-	auto& sys_like_def = get_system_like(system_id);
-	auto  gen_id = next_id<ecsact_system_generates_id>();
-	sys_like_def.generates[gen_id] = {};
-	return gen_id;
-}
-
-void ecsact_remove_system_generates(
-	ecsact_system_like_id      system_id,
-	ecsact_system_generates_id generates_id
-) {
-	auto& sys_like_def = get_system_like(system_id);
-	sys_like_def.generates.erase(generates_id);
-}
-
-void ecsact_system_generates_set_component(
-	ecsact_system_like_id      system_id,
-	ecsact_system_generates_id generates_id,
-	ecsact_component_id        component_id,
-	ecsact_system_generate     generate_flag
-) {
-	auto& sys_like_def = get_system_like(system_id);
-	auto& gen_comps = sys_like_def.generates.at(generates_id);
-	gen_comps[component_id] = generate_flag;
-}
-
-void ecsact_system_generates_unset_component(
-	ecsact_system_like_id      system_id,
-	ecsact_system_generates_id generates_id,
-	ecsact_component_id        component_id
-) {
-	auto& sys_like_def = get_system_like(system_id);
-	auto& gen_comps = sys_like_def.generates.at(generates_id);
-	gen_comps.erase(component_id);
-}
-
-int32_t ecsact_meta_count_system_generates_ids(
-	ecsact_system_like_id system_id
-) {
-	auto& sys_like_def = get_system_like(system_id);
-	return static_cast<int32_t>(sys_like_def.generates.size());
-}
-
-void ecsact_meta_system_generates_ids(
-	ecsact_system_like_id       system_id,
-	int32_t                     max_generates_ids_count,
-	ecsact_system_generates_id* out_generates_ids,
-	int32_t*                    out_generates_ids_count
-) {
-	auto& sys_like_def = get_system_like(system_id);
-
-	auto itr = sys_like_def.generates.begin();
-	for(int i = 0; max_generates_ids_count > i; ++i, ++itr) {
-		if(itr == sys_like_def.generates.end()) {
-			break;
-		}
-
-		out_generates_ids[i] = itr->first;
-	}
-
-	if(out_generates_ids_count != nullptr) {
-		*out_generates_ids_count =
-			static_cast<int32_t>(sys_like_def.generates.size());
-	}
-}
-
-int32_t ecsact_meta_count_system_generates_components(
-	ecsact_system_like_id      system_id,
-	ecsact_system_generates_id generates_id
-) {
-	auto& sys_like_def = get_system_like(system_id);
-	auto& gen_def = sys_like_def.generates.at(generates_id);
-	return static_cast<int32_t>(gen_def.size());
-}
-
-void ecsact_meta_system_generates_components(
-	ecsact_system_like_id      system_id,
-	ecsact_system_generates_id generates_id,
-	int32_t                    max_components_count,
-	ecsact_component_id*       out_component_ids,
-	ecsact_system_generate*    out_component_generate_flags,
-	int32_t*                   out_components_count
-) {
-	auto& sys_like_def = get_system_like(system_id);
-	auto& gen_def = sys_like_def.generates.at(generates_id);
-
-	auto itr = gen_def.begin();
-	for(int i = 0; max_components_count > i; ++i, ++itr) {
-		if(itr == gen_def.end()) {
-			break;
-		}
-
-		out_component_ids[i] = itr->first;
-		out_component_generate_flags[i] = itr->second;
-	}
-
-	if(out_components_count != nullptr) {
-		*out_components_count = static_cast<int32_t>(gen_def.size());
-	}
-}
-
-void ecsact_set_system_lazy_iteration_rate( //
-	ecsact_system_id system_id,
-	int32_t          iteration_rate
-) {
-	auto& def = sys_defs.at(system_id);
-	def.lazy_iteration_rate = iteration_rate;
-}
-
-int32_t ecsact_meta_get_lazy_iteration_rate( //
-	ecsact_system_id system_id
-) {
-	auto& def = sys_defs.at(system_id);
-	return def.lazy_iteration_rate;
-}
-
-void ecsact_set_system_parallel_execution( //
-	ecsact_system_like_id     system_like_id,
-	ecsact_parallel_execution parallel_execution
-) {
-	auto& def = get_system_like(system_like_id);
-	def.parallel_execution = parallel_execution;
-}
-
-ecsact_parallel_execution ecsact_meta_get_system_parallel_execution( //
-	ecsact_system_like_id system_like_id
-) {
-	auto& def = get_system_like(system_like_id);
-	return def.parallel_execution;
-}
-
-auto ecsact_meta_system_notify_settings_count(
-	ecsact_system_like_id system_like_id
-) -> int32_t {
-	auto& def = get_system_like(system_like_id);
-	return static_cast<int32_t>(def.notify_settings.size());
-}
-
-auto ecsact_meta_system_notify_settings(
-	ecsact_system_like_id         system_like_id,
-	int32_t                       max_notifies_count,
-	ecsact_component_like_id*     out_notify_component_ids,
-	ecsact_system_notify_setting* out_notify_settings,
-	int32_t*                      out_notifies_count
-) -> void {
-	auto& def = get_system_like(system_like_id);
-
-	auto itr = def.notify_settings.begin();
-	for(int i = 0; max_notifies_count > i; ++i) {
-		if(i >= def.notify_settings.size() || itr == def.notify_settings.end()) {
-			break;
-		}
-
-		out_notify_component_ids[i] = itr->first;
-		out_notify_settings[i] = itr->second;
-
-		++itr;
-	}
-
-	if(out_notifies_count != nullptr) {
-		*out_notifies_count = static_cast<int32_t>(def.notify_settings.size());
-	}
-}
-
-auto ecsact_set_system_notify_component_setting(
-	ecsact_system_like_id        system_like_id,
-	ecsact_component_like_id     component_like_id,
-	ecsact_system_notify_setting setting
-) -> void {
-	auto& def = get_system_like(system_like_id);
-	if(setting == ECSACT_SYS_NOTIFY_NONE) {
-		def.notify_settings.erase(component_like_id);
-	} else {
-		def.notify_settings[component_like_id] = setting;
-	}
-}
-
-auto ecsact_meta_component_type( //
-	ecsact_component_like_id comp_like_id
-) -> ecsact_component_type {
-	auto comp_def =
-		comp_defs.find(static_cast<ecsact_component_id>(comp_like_id));
-	if(comp_def == comp_defs.end()) {
-		// NOTE: this is temporary until we remove the transient fns and instead
-		// embrace components with transient statement params
-		auto trans_def =
-			trans_defs.find(static_cast<ecsact_transient_id>(comp_like_id));
-		if(trans_def != trans_defs.end()) {
-			return ECSACT_COMPONENT_TYPE_TRANSIENT;
-		}
-
-		return ECSACT_COMPONENT_TYPE_NONE;
-	}
-
-	return comp_def->second.comp_type;
-}
-
 static bool collect_all_caps(
 	ecsact_system_like_id system_id,
-	std::unordered_map<ecsact_component_like_id, ecsact_system_capability>&
-		out_caps
+	std::unordered_map<ecsact_component_like_id, ecsact_system_capability>& out_caps
 ) {
 	auto& sys_def = get_system_like(system_id);
 	bool  independent = !sys_def.generates.empty() ||
@@ -1186,12 +959,11 @@ static bool collect_all_caps(
 		);
 	}
 
-	for(auto child_sys_id : sys_def.nested_systems) {
-		if(collect_all_caps(
-				 ecsact_id_cast<ecsact_system_like_id>(child_sys_id),
-				 out_caps
-			 )) {
-			independent = true;
+	for(auto& entry : sys_def.execution_order) {
+		if(auto child_sys_id = std::get_if<ecsact_system_like_id>(&entry)) {
+			if(collect_all_caps(*child_sys_id, out_caps)) {
+				independent = true;
+			}
 		}
 	}
 
@@ -1199,9 +971,8 @@ static bool collect_all_caps(
 }
 
 static std::optional<ecsact_system_like_id> calculate_execution_batches(
-	const std::vector<ecsact_system_like_id>&        systems,
-	const std::vector<int32_t>&                      explicit_starts,
-	const std::vector<int32_t>&                      explicit_ends,
+	const std::vector<std::variant<ecsact_system_like_id, ecsact_cluster_id>>&
+		execution_order,
 	std::vector<std::vector<ecsact_system_like_id>>& out_batches
 ) {
 	out_batches.clear();
@@ -1274,88 +1045,121 @@ static std::optional<ecsact_system_like_id> calculate_execution_batches(
 		return false;
 	};
 
-	int32_t current_explicit_cluster_start = -1;
+	for(auto const& entry : execution_order) {
+		if(auto sys_id_ptr = std::get_if<ecsact_system_like_id>(&entry)) {
+			auto sys_id = *sys_id_ptr;
+			std::unordered_map<ecsact_component_like_id, ecsact_system_capability>
+				all_caps;
+			bool independent = collect_all_caps(sys_id, all_caps);
 
-	for(int32_t i = 0; static_cast<int32_t>(systems.size()) > i; ++i) {
-		auto sys_id = systems[i];
-		if(std::ranges::find(explicit_starts, i) != explicit_starts.end()) {
-			finalize_batch();
-			current_explicit_cluster_start = i;
-		}
-
-		std::unordered_map<ecsact_component_like_id, ecsact_system_capability>
-			all_caps;
-		bool independent = collect_all_caps(sys_id, all_caps);
-
-		bool conflict = independent;
-		if(!conflict) {
-			for(auto const& [comp_id, cap] : all_caps) {
-				bool comp_conflict = false;
-				if(is_exclusive(cap)) {
-					if(batch_readers.contains(comp_id) || batch_writers.contains(comp_id)) {
-						comp_conflict = true;
+			bool conflict = independent;
+			if(!conflict) {
+				for(auto const& [comp_id, cap] : all_caps) {
+					bool comp_conflict = false;
+					if(is_exclusive(cap)) {
+						if(batch_readers.contains(comp_id) || batch_writers.contains(comp_id)) {
+							comp_conflict = true;
+						}
 					}
-				}
-				if(is_reader(cap)) {
-					if(batch_writers.contains(comp_id)) {
-						comp_conflict = true;
-					}
-				}
-
-				if(comp_conflict) {
-					// Check if this system is mutually exclusive with EVERYTHING in the
-					// current batch that touched this component.
-					// For simplicity, we just check if it's mutually exclusive with
-					// ALL systems in the current batch.
-					bool all_exclusive = true;
-					for(auto other_sys_id : current_batch) {
-						if(!are_mutually_exclusive(sys_id, other_sys_id)) {
-							all_exclusive = false;
-							break;
+					if(is_reader(cap)) {
+						if(batch_writers.contains(comp_id)) {
+							comp_conflict = true;
 						}
 					}
 
-					if(!all_exclusive) {
-						conflict = true;
-						break;
+					if(comp_conflict) {
+						bool all_exclusive = true;
+						for(auto other_sys_id : current_batch) {
+							if(!are_mutually_exclusive(sys_id, other_sys_id)) {
+								all_exclusive = false;
+								break;
+							}
+						}
+
+						if(!all_exclusive) {
+							conflict = true;
+							break;
+						}
 					}
 				}
 			}
-		}
 
-		if(conflict) {
-			if(current_explicit_cluster_start != -1) {
-				return sys_id;
+			if(conflict) {
+				finalize_batch();
 			}
+
+			current_batch.push_back(sys_id);
+			for(auto const& [comp_id, cap] : all_caps) {
+				if(is_exclusive(cap)) {
+					batch_writers.insert(comp_id);
+				}
+				if(is_reader(cap)) {
+					batch_readers.insert(comp_id);
+				}
+			}
+
+			if(independent) {
+				finalize_batch();
+			}
+		} else if(auto cluster_id_ptr = std::get_if<ecsact_cluster_id>(&entry)) {
 			finalize_batch();
-		}
+			auto& cluster_def = cluster_defs.at(*cluster_id_ptr);
+			for(auto sys_id : cluster_def.systems) {
+				std::unordered_map<ecsact_component_like_id, ecsact_system_capability>
+					all_caps;
+				bool independent = collect_all_caps(sys_id, all_caps);
 
-		current_batch.push_back(sys_id);
-		for(auto const& [comp_id, cap] : all_caps) {
-			if(is_exclusive(cap)) {
-				batch_writers.insert(comp_id);
-			}
-			if(is_reader(cap)) {
-				batch_readers.insert(comp_id);
-			}
-		}
+				bool conflict = independent;
+				if(!conflict) {
+					for(auto const& [comp_id, cap] : all_caps) {
+						bool comp_conflict = false;
+						if(is_exclusive(cap)) {
+							if(batch_readers.contains(comp_id) || batch_writers.contains(comp_id)) {
+								comp_conflict = true;
+							}
+						}
+						if(is_reader(cap)) {
+							if(batch_writers.contains(comp_id)) {
+								comp_conflict = true;
+							}
+						}
 
-		if(independent) {
-			if(current_explicit_cluster_start != -1) {
-				// Independent systems always end their batch. If we're in an explicit
-				// cluster, then this system would be forced to be alone, which means
-				// the cluster is invalid if there are other systems.
-				// Wait - if the independent system is the FIRST in the cluster it's ok
-				if(current_explicit_cluster_start != i) {
+						if(comp_conflict) {
+							bool all_exclusive = true;
+							for(auto other_sys_id : current_batch) {
+								if(!are_mutually_exclusive(sys_id, other_sys_id)) {
+									all_exclusive = false;
+									break;
+								}
+							}
+
+							if(!all_exclusive) {
+								conflict = true;
+								break;
+							}
+						}
+					}
+				}
+
+				if(conflict) {
+					return sys_id;
+				}
+
+				current_batch.push_back(sys_id);
+				for(auto const& [comp_id, cap] : all_caps) {
+					if(is_exclusive(cap)) {
+						batch_writers.insert(comp_id);
+					}
+					if(is_reader(cap)) {
+						batch_readers.insert(comp_id);
+					}
+				}
+
+				if(independent && &sys_id != &cluster_def.systems.back()) {
 					return sys_id;
 				}
 			}
 			finalize_batch();
-		}
-
-		if(std::ranges::find(explicit_ends, i + 1) != explicit_ends.end()) {
-			finalize_batch();
-			current_explicit_cluster_start = -1;
 		}
 	}
 
@@ -1366,24 +1170,20 @@ static std::optional<ecsact_system_like_id> calculate_execution_batches(
 int32_t ecsact_meta_count_execution_batches(ecsact_package_id package_id) {
 	auto& pkg = package_defs.at(package_id);
 	if(pkg.execution_batches.empty()) {
-		std::vector<ecsact_system_like_id> all_systems;
+		std::vector<std::variant<ecsact_system_like_id, ecsact_cluster_id>>
+			all_execution_order;
 		for(auto dep_id : pkg.dependencies) {
 			auto& dep_pkg = package_defs.at(dep_id);
-			for(auto sys_id : dep_pkg.top_level_systems) {
-				all_systems.push_back(sys_id);
+			for(auto& entry : dep_pkg.execution_order) {
+				all_execution_order.push_back(entry);
 			}
 		}
-		for(auto sys_id : pkg.top_level_systems) {
-			all_systems.push_back(sys_id);
+		for(auto& entry : pkg.execution_order) {
+			all_execution_order.push_back(entry);
 		}
 
-		if(!all_systems.empty()) {
-			calculate_execution_batches(
-				all_systems,
-				pkg.explicit_cluster_starts,
-				pkg.explicit_cluster_ends,
-				pkg.execution_batches
-			);
+		if(!all_execution_order.empty()) {
+			calculate_execution_batches(all_execution_order, pkg.execution_batches);
 		}
 	}
 	return static_cast<int32_t>(pkg.execution_batches.size());
@@ -1398,24 +1198,20 @@ void ecsact_meta_get_execution_batch(
 ) {
 	auto& pkg = package_defs.at(package_id);
 	if(pkg.execution_batches.empty()) {
-		std::vector<ecsact_system_like_id> all_systems;
+		std::vector<std::variant<ecsact_system_like_id, ecsact_cluster_id>>
+			all_execution_order;
 		for(auto dep_id : pkg.dependencies) {
 			auto& dep_pkg = package_defs.at(dep_id);
-			for(auto sys_id : dep_pkg.top_level_systems) {
-				all_systems.push_back(sys_id);
+			for(auto& entry : dep_pkg.execution_order) {
+				all_execution_order.push_back(entry);
 			}
 		}
-		for(auto sys_id : pkg.top_level_systems) {
-			all_systems.push_back(sys_id);
+		for(auto& entry : pkg.execution_order) {
+			all_execution_order.push_back(entry);
 		}
 
-		if(!all_systems.empty()) {
-			calculate_execution_batches(
-				all_systems,
-				pkg.explicit_cluster_starts,
-				pkg.explicit_cluster_ends,
-				pkg.execution_batches
-			);
+		if(!all_execution_order.empty()) {
+			calculate_execution_batches(all_execution_order, pkg.execution_batches);
 		}
 	}
 
@@ -1435,15 +1231,9 @@ int32_t ecsact_meta_count_system_execution_batches(
 	ecsact_system_like_id system_id
 ) {
 	auto& sys_def = get_system_like(system_id);
-	if(sys_def.execution_batches.empty() && !sys_def.nested_systems.empty()) {
-		std::vector<ecsact_system_like_id> nested_systems;
-		for(auto id : sys_def.nested_systems) {
-			nested_systems.push_back(ecsact_id_cast<ecsact_system_like_id>(id));
-		}
+	if(sys_def.execution_batches.empty() && !sys_def.execution_order.empty()) {
 		calculate_execution_batches(
-			nested_systems,
-			sys_def.explicit_cluster_starts,
-			sys_def.explicit_cluster_ends,
+			sys_def.execution_order,
 			sys_def.execution_batches
 		);
 	}
@@ -1458,15 +1248,9 @@ void ecsact_meta_get_system_execution_batch(
 	int32_t*               out_systems_count
 ) {
 	auto& sys_def = get_system_like(system_id);
-	if(sys_def.execution_batches.empty() && !sys_def.nested_systems.empty()) {
-		std::vector<ecsact_system_like_id> nested_systems;
-		for(auto id : sys_def.nested_systems) {
-			nested_systems.push_back(ecsact_id_cast<ecsact_system_like_id>(id));
-		}
+	if(sys_def.execution_batches.empty() && !sys_def.execution_order.empty()) {
 		calculate_execution_batches(
-			nested_systems,
-			sys_def.explicit_cluster_starts,
-			sys_def.explicit_cluster_ends,
+			sys_def.execution_order,
 			sys_def.execution_batches
 		);
 	}
@@ -1487,28 +1271,24 @@ ecsact_system_like_id ecsact_check_execution_batches(
 	ecsact_package_id package_id
 ) {
 	auto& pkg = package_defs.at(package_id);
-	std::vector<ecsact_system_like_id> all_systems;
+	std::vector<std::variant<ecsact_system_like_id, ecsact_cluster_id>>
+		all_execution_order;
 	for(auto dep_id : pkg.dependencies) {
 		auto& dep_pkg = package_defs.at(dep_id);
-		for(auto sys_id : dep_pkg.top_level_systems) {
-			all_systems.push_back(sys_id);
+		for(auto& entry : dep_pkg.execution_order) {
+			all_execution_order.push_back(entry);
 		}
 	}
-	for(auto sys_id : pkg.top_level_systems) {
-		all_systems.push_back(sys_id);
+	for(auto& entry : pkg.execution_order) {
+		all_execution_order.push_back(entry);
 	}
 
-	if(all_systems.empty()) {
+	if(all_execution_order.empty()) {
 		return (ecsact_system_like_id)-1;
 	}
 
 	std::vector<std::vector<ecsact_system_like_id>> batches;
-	auto result = calculate_execution_batches(
-		all_systems,
-		pkg.explicit_cluster_starts,
-		pkg.explicit_cluster_ends,
-		batches
-	);
+	auto result = calculate_execution_batches(all_execution_order, batches);
 
 	return result.value_or((ecsact_system_like_id)-1);
 }
@@ -1517,22 +1297,12 @@ ecsact_system_like_id ecsact_check_system_execution_batches(
 	ecsact_system_like_id system_id
 ) {
 	auto& sys_def = get_system_like(system_id);
-	if(sys_def.nested_systems.empty()) {
+	if(sys_def.execution_order.empty()) {
 		return (ecsact_system_like_id)-1;
 	}
 
-	std::vector<ecsact_system_like_id> nested_systems;
-	for(auto id : sys_def.nested_systems) {
-		nested_systems.push_back(ecsact_id_cast<ecsact_system_like_id>(id));
-	}
-
 	std::vector<std::vector<ecsact_system_like_id>> batches;
-	auto result = calculate_execution_batches(
-		nested_systems,
-		sys_def.explicit_cluster_starts,
-		sys_def.explicit_cluster_ends,
-		batches
-	);
+	auto result = calculate_execution_batches(sys_def.execution_order, batches);
 
 	return result.value_or((ecsact_system_like_id)-1);
 }
@@ -1545,40 +1315,325 @@ bool ecsact_meta_is_action(ecsact_system_like_id system_id) {
 	return act_defs.contains(static_cast<ecsact_action_id>(system_id));
 }
 
-void ecsact_add_cluster(
+int32_t ecsact_meta_count_top_level_systems(ecsact_package_id package_id) {
+	auto&   pkg_def = package_defs.at(package_id);
+	int32_t count = 0;
+	for(auto& entry : pkg_def.execution_order) {
+		if(std::holds_alternative<ecsact_system_like_id>(entry)) {
+			count += 1;
+		}
+	}
+	return count;
+}
+
+void ecsact_meta_get_top_level_systems(
+	ecsact_package_id      package_id,
+	int32_t                max_systems_count,
+	ecsact_system_like_id* out_systems,
+	int32_t*               out_systems_count
+) {
+	auto&   pkg_def = package_defs.at(package_id);
+	int32_t count = 0;
+	for(auto& entry : pkg_def.execution_order) {
+		if(count >= max_systems_count) {
+			break;
+		}
+		if(auto sys_id = std::get_if<ecsact_system_like_id>(&entry)) {
+			out_systems[count++] = *sys_id;
+		}
+	}
+
+	if(out_systems_count != nullptr) {
+		*out_systems_count = count;
+	}
+}
+
+int32_t ecsact_meta_count_child_systems(ecsact_system_like_id system_id) {
+	auto&   def = get_system_like(system_id);
+	int32_t count = 0;
+	for(auto& entry : def.execution_order) {
+		if(auto inner_sys_id = std::get_if<ecsact_system_like_id>(&entry)) {
+			if(ecsact_meta_is_system(*inner_sys_id)) {
+				count += 1;
+			}
+		}
+	}
+	return count;
+}
+
+void ecsact_meta_get_child_system_ids(
+	ecsact_system_like_id system_id,
+	int32_t               max_child_system_ids_count,
+	ecsact_system_id*     out_child_system_ids,
+	int32_t*              out_child_system_count
+) {
+	auto&   def = get_system_like(system_id);
+	int32_t count = 0;
+	for(auto& entry : def.execution_order) {
+		if(count >= max_child_system_ids_count) {
+			break;
+		}
+		if(auto inner_sys_id = std::get_if<ecsact_system_like_id>(&entry)) {
+			if(ecsact_meta_is_system(*inner_sys_id)) {
+				out_child_system_ids[count++] =
+					static_cast<ecsact_system_id>(*inner_sys_id);
+			}
+		}
+	}
+
+	if(out_child_system_count) {
+		*out_child_system_count = count;
+	}
+}
+
+ecsact_system_like_id ecsact_meta_get_parent_system_id(
+	ecsact_system_id child_system_id
+) {
+	auto& def =
+		get_system_like(ecsact_id_cast<ecsact_system_like_id>(child_system_id));
+	return def.parent_system_id;
+}
+
+void ecsact_set_system_lazy_iteration_rate(
+	ecsact_system_id system_id,
+	int32_t          iteration_rate
+) {
+	auto& def = sys_defs.at(system_id);
+	def.lazy_iteration_rate = iteration_rate;
+}
+
+int32_t ecsact_meta_get_lazy_iteration_rate(ecsact_system_id system_id) {
+	auto& def = sys_defs.at(system_id);
+	return def.lazy_iteration_rate;
+}
+
+ecsact_system_generates_id ecsact_add_system_generates(
+	ecsact_system_like_id system_id
+) {
+	auto& sys_like_def = get_system_like(system_id);
+	auto  gen_id = next_id<ecsact_system_generates_id>();
+	sys_like_def.generates[gen_id] = {};
+	return gen_id;
+}
+
+void ecsact_remove_system_generates(
+	ecsact_system_like_id      system_id,
+	ecsact_system_generates_id generates_id
+) {
+	auto& sys_like_def = get_system_like(system_id);
+	sys_like_def.generates.erase(generates_id);
+}
+
+void ecsact_system_generates_set_component(
+	ecsact_system_like_id      system_id,
+	ecsact_system_generates_id generates_id,
+	ecsact_component_id        component_id,
+	ecsact_system_generate     generate_flag
+) {
+	auto& sys_like_def = get_system_like(system_id);
+	sys_like_def.generates.at(generates_id)[component_id] = generate_flag;
+}
+
+void ecsact_system_generates_unset_component(
+	ecsact_system_like_id      system_id,
+	ecsact_system_generates_id generates_id,
+	ecsact_component_id        component_id
+) {
+	auto& sys_like_def = get_system_like(system_id);
+	sys_like_def.generates.at(generates_id).erase(component_id);
+}
+
+int32_t ecsact_meta_count_system_generates_ids(ecsact_system_like_id system_id) {
+	auto& sys_like_def = get_system_like(system_id);
+	return static_cast<int32_t>(sys_like_def.generates.size());
+}
+
+void ecsact_meta_system_generates_ids(
+	ecsact_system_like_id       system_id,
+	int32_t                     max_generates_ids_count,
+	ecsact_system_generates_id* out_generates_ids,
+	int32_t*                    out_generates_ids_count
+) {
+	auto& def = get_system_like(system_id);
+	auto  itr = def.generates.begin();
+	for(int i = 0; max_generates_ids_count > i && itr != def.generates.end();
+			++i) {
+		out_generates_ids[i] = itr->first;
+		++itr;
+	}
+
+	if(out_generates_ids_count) {
+		*out_generates_ids_count = static_cast<int32_t>(def.generates.size());
+	}
+}
+
+int32_t ecsact_meta_count_system_generates_components(
+	ecsact_system_like_id      system_id,
+	ecsact_system_generates_id generates_id
+) {
+	auto& def = get_system_like(system_id);
+	return static_cast<int32_t>(def.generates.at(generates_id).size());
+}
+
+void ecsact_meta_system_generates_components(
+	ecsact_system_like_id      system_id,
+	ecsact_system_generates_id generates_id,
+	int32_t                    max_components_count,
+	ecsact_component_id*       out_component_ids,
+	ecsact_system_generate*    out_generate_flags,
+	int32_t*                   out_components_count
+) {
+	auto& def = get_system_like(system_id);
+	auto& gens = def.generates.at(generates_id);
+	auto  itr = gens.begin();
+	for(int i = 0; max_components_count > i && itr != gens.end(); ++i) {
+		out_component_ids[i] = itr->first;
+		out_generate_flags[i] = itr->second;
+		++itr;
+	}
+
+	if(out_components_count) {
+		*out_components_count = static_cast<int32_t>(gens.size());
+	}
+}
+
+void ecsact_set_system_parallel_execution(
+	ecsact_system_like_id     system_id,
+	ecsact_parallel_execution parallel_execution
+) {
+	auto& def = get_system_like(system_id);
+	def.parallel_execution = parallel_execution;
+}
+
+ecsact_parallel_execution ecsact_meta_get_system_parallel_execution(
+	ecsact_system_like_id system_id
+) {
+	auto& def = get_system_like(system_id);
+	return def.parallel_execution;
+}
+
+void ecsact_set_system_notify_component_setting(
+	ecsact_system_like_id        system_id,
+	ecsact_component_like_id     component_id,
+	ecsact_system_notify_setting setting
+) {
+	auto& def = get_system_like(system_id);
+	if(setting == ECSACT_SYS_NOTIFY_NONE) {
+		def.notify_settings.erase(component_id);
+	} else {
+		def.notify_settings[component_id] = setting;
+	}
+}
+
+int32_t ecsact_meta_system_notify_settings_count(
+	ecsact_system_like_id system_id
+) {
+	auto& def = get_system_like(system_id);
+	return static_cast<int32_t>(def.notify_settings.size());
+}
+
+void ecsact_meta_system_notify_settings(
+	ecsact_system_like_id         system_id,
+	int32_t                       max_settings_count,
+	ecsact_component_like_id*     out_component_ids,
+	ecsact_system_notify_setting* out_notify_settings,
+	int32_t*                      out_settings_count
+) {
+	auto& def = get_system_like(system_id);
+	auto  itr = def.notify_settings.begin();
+	for(int i = 0; max_settings_count > i && itr != def.notify_settings.end();
+			++i) {
+		out_component_ids[i] = itr->first;
+		out_notify_settings[i] = itr->second;
+		++itr;
+	}
+
+	if(out_settings_count) {
+		*out_settings_count = static_cast<int32_t>(def.notify_settings.size());
+	}
+}
+
+const char* ecsact_meta_cluster_name(ecsact_cluster_id cluster_id) {
+	return cluster_defs.at(cluster_id).name.c_str();
+}
+
+int32_t ecsact_meta_count_cluster_systems(ecsact_cluster_id cluster_id) {
+	return static_cast<int32_t>(cluster_defs.at(cluster_id).systems.size());
+}
+
+void ecsact_meta_get_cluster_systems(
+	ecsact_cluster_id      cluster_id,
+	int32_t                max_systems_count,
+	ecsact_system_like_id* out_systems,
+	int32_t*               out_systems_count
+) {
+	auto& def = cluster_defs.at(cluster_id);
+	auto  count =
+		std::min(max_systems_count, static_cast<int32_t>(def.systems.size()));
+
+	for(int i = 0; count > i; ++i) {
+		out_systems[i] = def.systems[i];
+	}
+
+	if(out_systems_count != nullptr) {
+		*out_systems_count = static_cast<int32_t>(def.systems.size());
+	}
+}
+
+ecsact_cluster_id ecsact_create_cluster(
 	ecsact_package_id package_id,
 	const char*       cluster_name,
 	int32_t           cluster_name_len
 ) {
 	auto& pkg = package_defs.at(package_id);
-	pkg.explicit_cluster_starts.push_back(
-		static_cast<int32_t>(pkg.top_level_systems.size())
-	);
+	auto  id = next_id<ecsact_cluster_id>();
+	auto& def = cluster_defs[id];
+	def.name = std::string(cluster_name, cluster_name_len);
+	pkg.execution_order.push_back(id);
+	return id;
 }
 
-void ecsact_add_system_cluster(
+ecsact_cluster_id ecsact_create_system_cluster(
 	ecsact_system_like_id parent_system_id,
 	const char*           cluster_name,
 	int32_t               cluster_name_len
 ) {
 	auto& sys = get_system_like(parent_system_id);
-	sys.explicit_cluster_starts.push_back(
-		static_cast<int32_t>(sys.nested_systems.size())
-	);
+	auto  id = next_id<ecsact_cluster_id>();
+	auto& def = cluster_defs[id];
+	def.name = std::string(cluster_name, cluster_name_len);
+	sys.execution_order.push_back(id);
+	return id;
 }
 
-void ecsact_end_cluster(ecsact_package_id package_id) {
-	auto& pkg = package_defs.at(package_id);
-	pkg.explicit_cluster_ends.push_back(
-		static_cast<int32_t>(pkg.top_level_systems.size())
-	);
-}
+void ecsact_add_system_to_cluster(
+	ecsact_cluster_id     cluster_id,
+	ecsact_system_like_id system_id
+) {
+	auto& def = cluster_defs.at(cluster_id);
+	def.systems.push_back(system_id);
 
-void ecsact_end_system_cluster(ecsact_system_like_id parent_system_id) {
-	auto& sys = get_system_like(parent_system_id);
-	sys.explicit_cluster_ends.push_back(
-		static_cast<int32_t>(sys.nested_systems.size())
+	auto owner_pkg_id = owner_package_id(system_id);
+	auto parent_sys_id = ecsact_meta_get_parent_system_id(
+		static_cast<ecsact_system_id>(system_id)
 	);
+
+	auto& execution_order = (int32_t)parent_sys_id == -1
+		? package_defs.at(owner_pkg_id).execution_order
+		: get_system_like(parent_sys_id).execution_order;
+
+	auto iter = std::find_if(
+		execution_order.begin(),
+		execution_order.end(),
+		[&](const auto& entry) {
+			auto sys_id = std::get_if<ecsact_system_like_id>(&entry);
+			return sys_id && *sys_id == system_id;
+		}
+	);
+
+	if(iter != execution_order.end()) {
+		execution_order.erase(iter);
+	}
 }
 
 auto ecsact_set_component_type( //
@@ -1591,4 +1646,14 @@ auto ecsact_set_component_type( //
 	}
 
 	comp_def->second.comp_type = comp_type;
+}
+
+ecsact_component_type ecsact_meta_component_type(
+	ecsact_component_like_id comp_like_id
+) {
+	auto comp_id = static_cast<ecsact_component_id>(comp_like_id);
+	if(!comp_defs.contains(comp_id)) {
+		return ECSACT_COMPONENT_TYPE_NONE;
+	}
+	return comp_defs.at(comp_id).comp_type;
 }

--- a/ecsact_interpret/parse-resolver-runtime/parse-resolver-runtime.cc
+++ b/ecsact_interpret/parse-resolver-runtime/parse-resolver-runtime.cc
@@ -1483,7 +1483,7 @@ void ecsact_meta_get_system_execution_batch(
 	}
 }
 
-ecsact_system_like_id ecsact_meta_check_execution_batches(
+ecsact_system_like_id ecsact_check_execution_batches(
 	ecsact_package_id package_id
 ) {
 	auto& pkg = package_defs.at(package_id);
@@ -1513,7 +1513,7 @@ ecsact_system_like_id ecsact_meta_check_execution_batches(
 	return result.value_or((ecsact_system_like_id)-1);
 }
 
-ecsact_system_like_id ecsact_meta_check_system_execution_batches(
+ecsact_system_like_id ecsact_check_system_execution_batches(
 	ecsact_system_like_id system_id
 ) {
 	auto& sys_def = get_system_like(system_id);
@@ -1545,7 +1545,7 @@ bool ecsact_meta_is_action(ecsact_system_like_id system_id) {
 	return act_defs.contains(static_cast<ecsact_action_id>(system_id));
 }
 
-void ecsact_meta_add_cluster(
+void ecsact_add_cluster(
 	ecsact_package_id package_id,
 	const char*       cluster_name,
 	int32_t           cluster_name_len
@@ -1556,7 +1556,7 @@ void ecsact_meta_add_cluster(
 	);
 }
 
-void ecsact_meta_add_system_cluster(
+void ecsact_add_system_cluster(
 	ecsact_system_like_id parent_system_id,
 	const char*           cluster_name,
 	int32_t               cluster_name_len
@@ -1567,14 +1567,14 @@ void ecsact_meta_add_system_cluster(
 	);
 }
 
-void ecsact_meta_end_cluster(ecsact_package_id package_id) {
+void ecsact_end_cluster(ecsact_package_id package_id) {
 	auto& pkg = package_defs.at(package_id);
 	pkg.explicit_cluster_ends.push_back(
 		static_cast<int32_t>(pkg.top_level_systems.size())
 	);
 }
 
-void ecsact_meta_end_system_cluster(ecsact_system_like_id parent_system_id) {
+void ecsact_end_system_cluster(ecsact_system_like_id parent_system_id) {
 	auto& sys = get_system_like(parent_system_id);
 	sys.explicit_cluster_ends.push_back(
 		static_cast<int32_t>(sys.nested_systems.size())

--- a/ecsact_interpret/test/BUILD.bazel
+++ b/ecsact_interpret/test/BUILD.bazel
@@ -121,3 +121,18 @@ cc_test(
         "@googletest//:gtest_main",
     ],
 )
+
+
+cc_test(
+    name = "explicit_clusters",
+    srcs = ["explicit_clusters.cc"],
+    copts = copts,
+    data = ["explicit_clusters.ecsact"],
+    deps = [
+        ":test_lib",
+        "//ecsact_interpret",
+        "//bazel/runfiles",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+    ],
+)

--- a/ecsact_interpret/test/BUILD.bazel
+++ b/ecsact_interpret/test/BUILD.bazel
@@ -136,3 +136,18 @@ cc_test(
         "@googletest//:gtest_main",
     ],
 )
+
+
+cc_test(
+    name = "zcpx_repro",
+    srcs = ["zcpx_repro.cc"],
+    copts = copts,
+    data = ["zcpx_repro.ecsact"],
+    deps = [
+        ":test_lib",
+        "//ecsact_interpret",
+        "//bazel/runfiles",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+    ],
+)

--- a/ecsact_interpret/test/errors/BUILD.bazel
+++ b/ecsact_interpret/test/errors/BUILD.bazel
@@ -3,6 +3,7 @@ load("//bazel:copts.bzl", "copts")
 
 # buildifier: keep sorted
 _TESTS = [
+    "cluster_invalid_conflict",
     "cluster_invalid_context",
     "cluster_invalid_statement",
     "duplicate_notice_components",

--- a/ecsact_interpret/test/errors/BUILD.bazel
+++ b/ecsact_interpret/test/errors/BUILD.bazel
@@ -3,6 +3,8 @@ load("//bazel:copts.bzl", "copts")
 
 # buildifier: keep sorted
 _TESTS = [
+    "cluster_invalid_context",
+    "cluster_invalid_statement",
     "duplicate_notice_components",
     "invalid_assoc_field",
     "invalid_notify_settings",

--- a/ecsact_interpret/test/errors/cluster_invalid_conflict.cc
+++ b/ecsact_interpret/test/errors/cluster_invalid_conflict.cc
@@ -1,0 +1,21 @@
+#include "gtest/gtest.h"
+#include <vector>
+#include <iostream>
+#include "ecsact/interpret/eval.hh"
+#include "bazel/runfiles/runfiles.hh"
+
+TEST(EcsactInterpret, ClusterInvalidConflictError) {
+	auto runfiles = bazel_sundry::CreateDefaultRunfiles();
+	ASSERT_TRUE(runfiles);
+
+	auto test_ecsact = runfiles->Rlocation(
+		"ecsact/ecsact_interpret/test/errors/cluster_invalid_conflict.ecsact"
+	);
+
+	auto errors = ecsact::eval_files({test_ecsact});
+	for(auto& err : errors) {
+		std::cerr << "[ERROR] " << err.error_message << " at " << err.line << ":" << err.character << "\n";
+	}
+	ASSERT_EQ(errors.size(), 1);
+	EXPECT_EQ(errors[0].eval_error, ECSACT_EVAL_ERR_INVALID_CLUSTER_SYSTEM);
+}

--- a/ecsact_interpret/test/errors/cluster_invalid_conflict.cc
+++ b/ecsact_interpret/test/errors/cluster_invalid_conflict.cc
@@ -14,7 +14,8 @@ TEST(EcsactInterpret, ClusterInvalidConflictError) {
 
 	auto errors = ecsact::eval_files({test_ecsact});
 	for(auto& err : errors) {
-		std::cerr << "[ERROR] " << err.error_message << " at " << err.line << ":" << err.character << "\n";
+		std::cerr << "[ERROR] " << err.error_message << " at " << err.line << ":"
+							<< err.character << "\n";
 	}
 	ASSERT_EQ(errors.size(), 1);
 	EXPECT_EQ(errors[0].eval_error, ECSACT_EVAL_ERR_INVALID_CLUSTER_SYSTEM);

--- a/ecsact_interpret/test/errors/cluster_invalid_conflict.ecsact
+++ b/ecsact_interpret/test/errors/cluster_invalid_conflict.ecsact
@@ -1,0 +1,12 @@
+main package cluster_invalid_conflict;
+
+component CompA { i32 a; }
+
+cluster {
+	system SysA {
+		readonly CompA;
+	}
+	system SysB {
+		readwrite CompA;
+	}
+}

--- a/ecsact_interpret/test/errors/cluster_invalid_context.cc
+++ b/ecsact_interpret/test/errors/cluster_invalid_context.cc
@@ -1,0 +1,19 @@
+#include "gtest/gtest.h"
+#include <vector>
+#include "ecsact/interpret/eval.hh"
+#include "bazel/runfiles/runfiles.hh"
+
+TEST(EcsactInterpret, ClusterInvalidContextError) {
+	auto runfiles = bazel_sundry::CreateDefaultRunfiles();
+	ASSERT_TRUE(runfiles);
+
+	auto test_ecsact = runfiles->Rlocation(
+		"ecsact/ecsact_interpret/test/errors/cluster_invalid_context.ecsact"
+	);
+
+	auto errors = ecsact::eval_files({test_ecsact});
+	ASSERT_EQ(errors.size(), 1);
+	EXPECT_EQ(errors[0].eval_error, ECSACT_EVAL_ERR_INVALID_CONTEXT);
+	EXPECT_EQ(errors[0].line, 3);
+	EXPECT_EQ(errors[0].character, 1);
+}

--- a/ecsact_interpret/test/errors/cluster_invalid_context.ecsact
+++ b/ecsact_interpret/test/errors/cluster_invalid_context.ecsact
@@ -1,0 +1,7 @@
+main package cluster_invalid_context;
+
+component CompA {
+	cluster {
+		system SysA {}
+	}
+}

--- a/ecsact_interpret/test/errors/cluster_invalid_statement.cc
+++ b/ecsact_interpret/test/errors/cluster_invalid_statement.cc
@@ -3,18 +3,17 @@
 #include "ecsact/interpret/eval.hh"
 #include "bazel/runfiles/runfiles.hh"
 
-TEST(EcsactInterpret, ClusterInvalidContextError) {
+TEST(EcsactInterpret, ClusterInvalidStatementError) {
 	auto runfiles = bazel_sundry::CreateDefaultRunfiles();
 	ASSERT_TRUE(runfiles);
 
 	auto test_ecsact = runfiles->Rlocation(
-		"ecsact/ecsact_interpret/test/errors/cluster_invalid_context.ecsact"
+		"ecsact/ecsact_interpret/test/errors/cluster_invalid_statement.ecsact"
 	);
 
 	auto errors = ecsact::eval_files({test_ecsact});
-	ASSERT_EQ(errors.size(), 2);
-	EXPECT_EQ(errors[0].eval_error, 0); // parse error
+	ASSERT_EQ(errors.size(), 1);
+	EXPECT_EQ(errors[0].eval_error, ECSACT_EVAL_ERR_INVALID_CONTEXT);
 	EXPECT_EQ(errors[0].line, 3);
-	EXPECT_EQ(errors[1].eval_error, ECSACT_EVAL_ERR_INVALID_CONTEXT);
-	EXPECT_EQ(errors[1].line, 4);
+	EXPECT_EQ(errors[0].character, 18);
 }

--- a/ecsact_interpret/test/errors/cluster_invalid_statement.ecsact
+++ b/ecsact_interpret/test/errors/cluster_invalid_statement.ecsact
@@ -1,0 +1,5 @@
+main package cluster_invalid_statement;
+
+cluster {
+	component CompA {}
+}

--- a/ecsact_interpret/test/explicit_clusters.cc
+++ b/ecsact_interpret/test/explicit_clusters.cc
@@ -21,7 +21,8 @@ TEST(EcsactInterpret, ExplicitClusters) {
 
 	auto errors = ecsact::eval_files({test_ecsact});
 	for(auto& err : errors) {
-		std::cerr << "[ERROR] " << test_ecsact << ":" << err.line << ":" << err.character << " " << err.error_message << "\n";
+		std::cerr << "[ERROR] " << test_ecsact << ":" << err.line << ":"
+							<< err.character << " " << err.error_message << "\n";
 	}
 	ASSERT_TRUE(errors.empty());
 
@@ -33,27 +34,51 @@ TEST(EcsactInterpret, ExplicitClusters) {
 
 	// Batch 0: SysA
 	{
-		int32_t systems_count = 0;
+		int32_t                            systems_count = 0;
 		std::vector<ecsact_system_like_id> systems(10);
-		ecsact_meta_get_execution_batch(package_id, 0, 10, systems.data(), &systems_count);
+		ecsact_meta_get_execution_batch(
+			package_id,
+			0,
+			10,
+			systems.data(),
+			&systems_count
+		);
 		ASSERT_EQ(systems_count, 1);
-		EXPECT_STREQ(ecsact_meta_system_name(static_cast<ecsact_system_id>(systems[0])), "SysA");
+		EXPECT_STREQ(
+			ecsact_meta_system_name(static_cast<ecsact_system_id>(systems[0])),
+			"SysA"
+		);
 	}
 
 	// Batch 1: SysB
 	{
-		int32_t systems_count = 0;
+		int32_t                            systems_count = 0;
 		std::vector<ecsact_system_like_id> systems(10);
-		ecsact_meta_get_execution_batch(package_id, 1, 10, systems.data(), &systems_count);
+		ecsact_meta_get_execution_batch(
+			package_id,
+			1,
+			10,
+			systems.data(),
+			&systems_count
+		);
 		ASSERT_EQ(systems_count, 1);
-		EXPECT_STREQ(ecsact_meta_system_name(static_cast<ecsact_system_id>(systems[0])), "SysB");
+		EXPECT_STREQ(
+			ecsact_meta_system_name(static_cast<ecsact_system_id>(systems[0])),
+			"SysB"
+		);
 	}
 
 	// Batch 2: ParentSys
 	{
-		int32_t systems_count = 0;
+		int32_t                            systems_count = 0;
 		std::vector<ecsact_system_like_id> systems(10);
-		ecsact_meta_get_execution_batch(package_id, 2, 10, systems.data(), &systems_count);
+		ecsact_meta_get_execution_batch(
+			package_id,
+			2,
+			10,
+			systems.data(),
+			&systems_count
+		);
 		ASSERT_EQ(systems_count, 1);
 		auto parent_sys_id = static_cast<ecsact_system_id>(systems[0]);
 		EXPECT_STREQ(ecsact_meta_system_name(parent_sys_id), "ParentSys");
@@ -65,7 +90,7 @@ TEST(EcsactInterpret, ExplicitClusters) {
 
 		// ParentSys Batch 0: ChildA
 		{
-			int32_t           sys_systems_count = 0;
+			int32_t               sys_systems_count = 0;
 			ecsact_system_like_id sys_systems[10];
 			ecsact_meta_get_system_execution_batch(
 				static_cast<ecsact_system_like_id>(parent_sys_id),
@@ -75,12 +100,15 @@ TEST(EcsactInterpret, ExplicitClusters) {
 				&sys_systems_count
 			);
 			ASSERT_EQ(sys_systems_count, 1);
-			EXPECT_STREQ(ecsact_meta_system_name(static_cast<ecsact_system_id>(sys_systems[0])), "ChildA");
+			EXPECT_STREQ(
+				ecsact_meta_system_name(static_cast<ecsact_system_id>(sys_systems[0])),
+				"ChildA"
+			);
 		}
 
 		// ParentSys Batch 1: ChildB
 		{
-			int32_t           sys_systems_count = 0;
+			int32_t               sys_systems_count = 0;
 			ecsact_system_like_id sys_systems[10];
 			ecsact_meta_get_system_execution_batch(
 				static_cast<ecsact_system_like_id>(parent_sys_id),
@@ -90,17 +118,32 @@ TEST(EcsactInterpret, ExplicitClusters) {
 				&sys_systems_count
 			);
 			ASSERT_EQ(sys_systems_count, 1);
-			EXPECT_STREQ(ecsact_meta_system_name(static_cast<ecsact_system_id>(sys_systems[0])), "ChildB");
+			EXPECT_STREQ(
+				ecsact_meta_system_name(static_cast<ecsact_system_id>(sys_systems[0])),
+				"ChildB"
+			);
 		}
 	}
 
 	// Batch 3: SysC, SysD (Mutually Exclusive)
 	{
-		int32_t systems_count = 0;
+		int32_t                            systems_count = 0;
 		std::vector<ecsact_system_like_id> systems(10);
-		ecsact_meta_get_execution_batch(package_id, 3, 10, systems.data(), &systems_count);
+		ecsact_meta_get_execution_batch(
+			package_id,
+			3,
+			10,
+			systems.data(),
+			&systems_count
+		);
 		ASSERT_EQ(systems_count, 2);
-		EXPECT_STREQ(ecsact_meta_system_name(static_cast<ecsact_system_id>(systems[0])), "SysC");
-		EXPECT_STREQ(ecsact_meta_system_name(static_cast<ecsact_system_id>(systems[1])), "SysD");
+		EXPECT_STREQ(
+			ecsact_meta_system_name(static_cast<ecsact_system_id>(systems[0])),
+			"SysC"
+		);
+		EXPECT_STREQ(
+			ecsact_meta_system_name(static_cast<ecsact_system_id>(systems[1])),
+			"SysD"
+		);
 	}
 }

--- a/ecsact_interpret/test/explicit_clusters.cc
+++ b/ecsact_interpret/test/explicit_clusters.cc
@@ -29,7 +29,7 @@ TEST(EcsactInterpret, ExplicitClusters) {
 	ASSERT_NE(package_id, (ecsact_package_id)-1);
 
 	auto batch_count = ecsact_meta_count_execution_batches(package_id);
-	ASSERT_EQ(batch_count, 3);
+	ASSERT_EQ(batch_count, 4);
 
 	// Batch 0: SysA
 	{
@@ -92,5 +92,15 @@ TEST(EcsactInterpret, ExplicitClusters) {
 			ASSERT_EQ(sys_systems_count, 1);
 			EXPECT_STREQ(ecsact_meta_system_name(static_cast<ecsact_system_id>(sys_systems[0])), "ChildB");
 		}
+	}
+
+	// Batch 3: SysC, SysD (Mutually Exclusive)
+	{
+		int32_t systems_count = 0;
+		std::vector<ecsact_system_like_id> systems(10);
+		ecsact_meta_get_execution_batch(package_id, 3, 10, systems.data(), &systems_count);
+		ASSERT_EQ(systems_count, 2);
+		EXPECT_STREQ(ecsact_meta_system_name(static_cast<ecsact_system_id>(systems[0])), "SysC");
+		EXPECT_STREQ(ecsact_meta_system_name(static_cast<ecsact_system_id>(systems[1])), "SysD");
 	}
 }

--- a/ecsact_interpret/test/explicit_clusters.cc
+++ b/ecsact_interpret/test/explicit_clusters.cc
@@ -1,0 +1,96 @@
+#include "gtest/gtest.h"
+#include <vector>
+#include <string>
+#include <filesystem>
+#include "ecsact/runtime/meta.h"
+#include "ecsact/runtime/meta.hh"
+#include "ecsact/interpret/eval.hh"
+#include "bazel/runfiles/runfiles.hh"
+
+namespace fs = std::filesystem;
+
+TEST(EcsactInterpret, ExplicitClusters) {
+	auto runfiles = bazel_sundry::CreateDefaultRunfiles();
+	ASSERT_TRUE(runfiles);
+
+	auto test_ecsact = runfiles->Rlocation(
+		"ecsact/ecsact_interpret/test/explicit_clusters.ecsact"
+	);
+	ASSERT_FALSE(test_ecsact.empty());
+	ASSERT_TRUE(fs::exists(test_ecsact));
+
+	auto errors = ecsact::eval_files({test_ecsact});
+	for(auto& err : errors) {
+		std::cerr << "[ERROR] " << test_ecsact << ":" << err.line << ":" << err.character << " " << err.error_message << "\n";
+	}
+	ASSERT_TRUE(errors.empty());
+
+	auto package_id = ecsact_meta_main_package();
+	ASSERT_NE(package_id, (ecsact_package_id)-1);
+
+	auto batch_count = ecsact_meta_count_execution_batches(package_id);
+	ASSERT_EQ(batch_count, 3);
+
+	// Batch 0: SysA
+	{
+		int32_t systems_count = 0;
+		std::vector<ecsact_system_like_id> systems(10);
+		ecsact_meta_get_execution_batch(package_id, 0, 10, systems.data(), &systems_count);
+		ASSERT_EQ(systems_count, 1);
+		EXPECT_STREQ(ecsact_meta_system_name(static_cast<ecsact_system_id>(systems[0])), "SysA");
+	}
+
+	// Batch 1: SysB
+	{
+		int32_t systems_count = 0;
+		std::vector<ecsact_system_like_id> systems(10);
+		ecsact_meta_get_execution_batch(package_id, 1, 10, systems.data(), &systems_count);
+		ASSERT_EQ(systems_count, 1);
+		EXPECT_STREQ(ecsact_meta_system_name(static_cast<ecsact_system_id>(systems[0])), "SysB");
+	}
+
+	// Batch 2: ParentSys
+	{
+		int32_t systems_count = 0;
+		std::vector<ecsact_system_like_id> systems(10);
+		ecsact_meta_get_execution_batch(package_id, 2, 10, systems.data(), &systems_count);
+		ASSERT_EQ(systems_count, 1);
+		auto parent_sys_id = static_cast<ecsact_system_id>(systems[0]);
+		EXPECT_STREQ(ecsact_meta_system_name(parent_sys_id), "ParentSys");
+
+		auto sys_batch_count = ecsact_meta_count_system_execution_batches(
+			static_cast<ecsact_system_like_id>(parent_sys_id)
+		);
+		ASSERT_EQ(sys_batch_count, 2);
+
+		// ParentSys Batch 0: ChildA
+		{
+			int32_t           sys_systems_count = 0;
+			ecsact_system_like_id sys_systems[10];
+			ecsact_meta_get_system_execution_batch(
+				static_cast<ecsact_system_like_id>(parent_sys_id),
+				0,
+				10,
+				sys_systems,
+				&sys_systems_count
+			);
+			ASSERT_EQ(sys_systems_count, 1);
+			EXPECT_STREQ(ecsact_meta_system_name(static_cast<ecsact_system_id>(sys_systems[0])), "ChildA");
+		}
+
+		// ParentSys Batch 1: ChildB
+		{
+			int32_t           sys_systems_count = 0;
+			ecsact_system_like_id sys_systems[10];
+			ecsact_meta_get_system_execution_batch(
+				static_cast<ecsact_system_like_id>(parent_sys_id),
+				1,
+				10,
+				sys_systems,
+				&sys_systems_count
+			);
+			ASSERT_EQ(sys_systems_count, 1);
+			EXPECT_STREQ(ecsact_meta_system_name(static_cast<ecsact_system_id>(sys_systems[0])), "ChildB");
+		}
+	}
+}

--- a/ecsact_interpret/test/explicit_clusters.ecsact
+++ b/ecsact_interpret/test/explicit_clusters.ecsact
@@ -27,3 +27,17 @@ system ParentSys {
 	}
 }
 
+component CompB;
+
+cluster {
+	system SysC {
+		readonly CompA;
+		include CompB;
+	}
+	system SysD {
+		readwrite CompA;
+		exclude CompB;
+	}
+}
+
+

--- a/ecsact_interpret/test/explicit_clusters.ecsact
+++ b/ecsact_interpret/test/explicit_clusters.ecsact
@@ -1,0 +1,29 @@
+main package explicit_clusters_test;
+
+component CompA { i32 a; }
+
+cluster {
+	system SysA {
+		readonly CompA;
+	}
+}
+
+cluster {
+	system SysB {
+		readonly CompA;
+	}
+}
+
+system ParentSys {
+	cluster {
+		system ChildA {
+			readonly CompA;
+		}
+	}
+	cluster {
+		system ChildB {
+			readonly CompA;
+		}
+	}
+}
+

--- a/ecsact_interpret/test/zcpx_repro.cc
+++ b/ecsact_interpret/test/zcpx_repro.cc
@@ -13,15 +13,15 @@ TEST(EcsactInterpret, ZcpxRepro) {
 	auto runfiles = bazel_sundry::CreateDefaultRunfiles();
 	ASSERT_TRUE(runfiles);
 
-	auto test_ecsact = runfiles->Rlocation(
-		"ecsact/ecsact_interpret/test/zcpx_repro.ecsact"
-	);
+	auto test_ecsact =
+		runfiles->Rlocation("ecsact/ecsact_interpret/test/zcpx_repro.ecsact");
 	ASSERT_FALSE(test_ecsact.empty());
 	ASSERT_TRUE(fs::exists(test_ecsact));
 
 	auto errors = ecsact::eval_files({test_ecsact});
 	for(auto& err : errors) {
-		std::cerr << "[ERROR] " << test_ecsact << ":" << err.line << ":" << err.character << " " << err.error_message << "\n";
+		std::cerr << "[ERROR] " << test_ecsact << ":" << err.line << ":"
+							<< err.character << " " << err.error_message << "\n";
 	}
 	ASSERT_TRUE(errors.empty());
 

--- a/ecsact_interpret/test/zcpx_repro.cc
+++ b/ecsact_interpret/test/zcpx_repro.cc
@@ -1,0 +1,37 @@
+#include "gtest/gtest.h"
+#include <vector>
+#include <string>
+#include <filesystem>
+#include "ecsact/runtime/meta.h"
+#include "ecsact/runtime/meta.hh"
+#include "ecsact/interpret/eval.hh"
+#include "bazel/runfiles/runfiles.hh"
+
+namespace fs = std::filesystem;
+
+TEST(EcsactInterpret, ZcpxRepro) {
+	auto runfiles = bazel_sundry::CreateDefaultRunfiles();
+	ASSERT_TRUE(runfiles);
+
+	auto test_ecsact = runfiles->Rlocation(
+		"ecsact/ecsact_interpret/test/zcpx_repro.ecsact"
+	);
+	ASSERT_FALSE(test_ecsact.empty());
+	ASSERT_TRUE(fs::exists(test_ecsact));
+
+	auto errors = ecsact::eval_files({test_ecsact});
+	for(auto& err : errors) {
+		std::cerr << "[ERROR] " << test_ecsact << ":" << err.line << ":" << err.character << " " << err.error_message << "\n";
+	}
+	ASSERT_TRUE(errors.empty());
+
+	auto package_id = ecsact_meta_main_package();
+	ASSERT_NE(package_id, (ecsact_package_id)-1);
+
+	auto batch_count = ecsact_meta_count_execution_batches(package_id);
+	ASSERT_EQ(batch_count, 1);
+
+	int32_t systems_count = 0;
+	ecsact_meta_get_execution_batch(package_id, 0, 0, nullptr, &systems_count);
+	ASSERT_EQ(systems_count, 3);
+}

--- a/ecsact_interpret/test/zcpx_repro.ecsact
+++ b/ecsact_interpret/test/zcpx_repro.ecsact
@@ -1,0 +1,34 @@
+main package zcpx_repro;
+
+component MoveDirection;
+component Attacking;
+component AnimState { i32 state; }
+component Lifetime;
+component Position;
+component Velocity;
+
+cluster {
+	system AnimEvalGeneric {
+		readwrite AnimState;
+		readonly Lifetime;
+		exclude MoveDirection;
+		exclude Attacking;
+	}
+
+	system AnimEvalMovement {
+		include MoveDirection;
+		readonly Position;
+		readonly Velocity;
+		readonly Lifetime;
+		readwrite AnimState;
+		exclude Attacking;
+	}
+
+	system AnimEvalAttacking {
+		readonly Position;
+		readonly Velocity;
+		readonly Lifetime;
+		readwrite AnimState;
+		readonly Attacking;
+	}
+}

--- a/ecsact_parse/ecsact/detail/grammar.hh
+++ b/ecsact_parse/ecsact/detail/grammar.hh
@@ -387,6 +387,35 @@ struct system_statement {
 	);
 };
 
+struct cluster_statement {
+	static constexpr auto name() {
+		return "cluster statement";
+	}
+
+	struct cluster_keyword : lexy::transparent_production {
+		static constexpr auto rule = LEXY_LIT("cluster");
+		static constexpr auto value = lexy::noop;
+	};
+
+	static constexpr auto rule = lexy::dsl::p<cluster_keyword> >>
+		lexy::dsl::opt(lexy::dsl::p<type_name_decl>);
+
+	static constexpr auto value = lexy::callback<ecsact_statement>(
+		[](std::optional<std::string_view> cluster_name) {
+			return ecsact_statement{
+				.type = ECSACT_STATEMENT_CLUSTER,
+				.data{.cluster_statement{
+					.cluster_name{
+						.data = cluster_name ? cluster_name->data() : nullptr,
+						.length =
+							cluster_name ? static_cast<int>(cluster_name->size()) : 0,
+					},
+				}},
+			};
+		}
+	);
+};
+
 struct action_statement {
 	static constexpr auto name() {
 		return "action statement";
@@ -988,6 +1017,7 @@ constexpr char top_level_statement_expected_message[] =
 using top_level_statement = statement<
 	top_level_statement_name,
 	top_level_statement_expected_message,
+	cluster_statement,
 	package_statement,
 	import_statement,
 	component_statement,
@@ -1035,10 +1065,20 @@ constexpr char system_level_statement_expected_message[] =
 using system_level_statement = statement<
 	system_level_statement_name,
 	system_level_statement_expected_message,
+	cluster_statement,
 	system_notify_statement,
 	system_component_statement,
 	generates_statement,
 	system_statement>;
+
+constexpr char cluster_level_statement_name[] = "cluster level statement";
+constexpr char cluster_level_statement_expected_message[] =
+	"expected cluster level statement";
+using cluster_level_statement = statement<
+	cluster_level_statement_name,
+	cluster_level_statement_expected_message,
+	system_statement,
+	action_statement>;
 
 constexpr char action_level_statement_name[] = "action level statement";
 constexpr char action_level_statement_expected_message[] =
@@ -1046,6 +1086,7 @@ constexpr char action_level_statement_expected_message[] =
 using action_level_statement = statement<
 	action_level_statement_name,
 	action_level_statement_expected_message,
+	cluster_statement,
 	system_notify_statement,
 	field_statement,
 	system_component_statement,

--- a/ecsact_parse/ecsact/detail/grammar.hh
+++ b/ecsact_parse/ecsact/detail/grammar.hh
@@ -1077,8 +1077,14 @@ constexpr char cluster_level_statement_expected_message[] =
 using cluster_level_statement = statement<
 	cluster_level_statement_name,
 	cluster_level_statement_expected_message,
+	package_statement,
+	import_statement,
+	component_statement,
+	transient_statement,
 	system_statement,
-	action_statement>;
+	action_statement,
+	enum_statement,
+	cluster_statement>;
 
 constexpr char action_level_statement_name[] = "action level statement";
 constexpr char action_level_statement_expected_message[] =

--- a/ecsact_parse/ecsact/detail/grammar.hh
+++ b/ecsact_parse/ecsact/detail/grammar.hh
@@ -407,8 +407,7 @@ struct cluster_statement {
 				.data{.cluster_statement{
 					.cluster_name{
 						.data = cluster_name ? cluster_name->data() : nullptr,
-						.length =
-							cluster_name ? static_cast<int>(cluster_name->size()) : 0,
+						.length = cluster_name ? static_cast<int>(cluster_name->size()) : 0,
 					},
 				}},
 			};

--- a/ecsact_parse/ecsact/ecsact_parse_statement.cc
+++ b/ecsact_parse/ecsact/ecsact_parse_statement.cc
@@ -49,6 +49,8 @@ static auto context_grammar(ecsact_statement_type context_type, Fn&& fn) {
 			return fn(grammar::system_notify_level_statement{});
 		case ECSACT_STATEMENT_SYSTEM_NOTIFY_COMPONENT:
 			return fn(grammar::system_notify_component_level_statement{});
+		case ECSACT_STATEMENT_CLUSTER:
+			return fn(grammar::cluster_level_statement{});
 	}
 
 	assert(false && "unhandled context grammar");

--- a/ecsact_parse/ecsact/parse/statements.h
+++ b/ecsact_parse/ecsact/parse/statements.h
@@ -29,6 +29,7 @@ typedef enum {
 	ECSACT_STATEMENT_ENTITY_CONSTRAINT,
 	ECSACT_STATEMENT_SYSTEM_NOTIFY,
 	ECSACT_STATEMENT_SYSTEM_NOTIFY_COMPONENT,
+	ECSACT_STATEMENT_CLUSTER,
 } ecsact_statement_type;
 
 typedef struct {
@@ -136,6 +137,10 @@ typedef struct {
 	ecsact_statement_sv component_name;
 } ecsact_system_notify_component_statement;
 
+typedef struct {
+	ecsact_statement_sv cluster_name;
+} ecsact_cluster_statement;
+
 typedef union {
 	ecsact_package_statement                 package_statement;
 	ecsact_import_statement                  import_statement;
@@ -152,6 +157,7 @@ typedef union {
 	ecsact_entity_constraint_statement       entity_constraint_statement;
 	ecsact_system_notify_statement           system_notify_statement;
 	ecsact_system_notify_component_statement system_notify_component_statement;
+	ecsact_cluster_statement                 cluster_statement;
 } ecsact_statement_data;
 
 typedef struct ecsact_statement {

--- a/ecsact_rt_entt/rt_entt_codegen/shared/ecsact_entt_details.cc
+++ b/ecsact_rt_entt/rt_entt_codegen/shared/ecsact_entt_details.cc
@@ -9,20 +9,10 @@
 using ecsact::rt_entt_codegen::ecsact_entt_details;
 using ecsact::rt_entt_codegen::ecsact_entt_system_details;
 
-static auto collect_top_level_systems( //
+static auto collect_top_level_systems(
 	ecsact_package_id    pkg_id,
 	ecsact_entt_details& details
 ) -> void {
-	auto deps = ecsact::meta::get_dependencies(pkg_id);
-	for(auto dep : deps) {
-		auto tl_sys_ids = ecsact::meta::get_top_level_systems(dep);
-		details.top_execution_order.insert(
-			details.top_execution_order.end(),
-			tl_sys_ids.begin(),
-			tl_sys_ids.end()
-		);
-	}
-
 	auto main_tl_sys_ids = ecsact::meta::get_top_level_systems(pkg_id);
 	details.top_execution_order.insert(
 		details.top_execution_order.end(),
@@ -31,19 +21,41 @@ static auto collect_top_level_systems( //
 	);
 }
 
-static auto collect_all_systems( //
+static auto collect_all_systems_recursive(
+	ecsact_system_like_id id,
+	ecsact_entt_details&  details
+) -> void {
+	if(ecsact_meta_is_system(id)) {
+		details.all_systems.insert(static_cast<ecsact_system_id>(id));
+	}
+
+	for(auto child_id : ecsact::meta::get_child_system_ids(id)) {
+		collect_all_systems_recursive(
+			static_cast<ecsact_system_like_id>(child_id),
+			details
+		);
+	}
+}
+
+static auto collect_all_systems(
 	ecsact_package_id    pkg_id,
 	ecsact_entt_details& details
 ) -> void {
 	auto deps = ecsact::meta::get_dependencies(pkg_id);
 	for(auto dep : deps) {
 		for(auto id : ecsact::meta::get_system_ids(dep)) {
-			details.all_systems.insert(id);
+			collect_all_systems_recursive(
+				static_cast<ecsact_system_like_id>(id),
+				details
+			);
 		}
 	}
 
 	for(auto id : ecsact::meta::get_system_ids(pkg_id)) {
-		details.all_systems.insert(id);
+		collect_all_systems_recursive(
+			static_cast<ecsact_system_like_id>(id),
+			details
+		);
 	}
 }
 

--- a/ecsact_runtime/ecsact/runtime/common.h
+++ b/ecsact_runtime/ecsact/runtime/common.h
@@ -71,6 +71,7 @@ ECSACT_TYPED_ID(ecsact_placeholder_entity_id);
 ECSACT_TYPED_ID(ecsact_system_generates_id);
 ECSACT_TYPED_ID(ecsact_async_session_id);
 ECSACT_TYPED_ID(ecsact_async_request_id);
+ECSACT_TYPED_ID(ecsact_cluster_id);
 
 ECSACT_TYPED_ID(ecsact_decl_id);
 ECSACT_TYPED_ID(ecsact_composite_id);
@@ -135,6 +136,8 @@ ECSACT_CAST_ID_FN(ecsact_variant_id, ecsact_decl_id)
 ECSACT_CAST_ID_FN(ecsact_system_like_id, ecsact_decl_id)
 ECSACT_CAST_ID_FN(ecsact_composite_id, ecsact_decl_id)
 ECSACT_CAST_ID_FN(ecsact_component_like_id, ecsact_decl_id)
+ECSACT_CAST_ID_FN(ecsact_cluster_id, ecsact_decl_id)
+ECSACT_CAST_ID_FN(ecsact_enum_id, ecsact_decl_id)
 
 ECSACT_CAST_ID_FN(ecsact_component_id, ecsact_component_like_id)
 ECSACT_CAST_ID_FN(ecsact_transient_id, ecsact_component_like_id)

--- a/ecsact_runtime/ecsact/runtime/dynamic.h
+++ b/ecsact_runtime/ecsact/runtime/dynamic.h
@@ -544,28 +544,24 @@ ECSACT_DYNAMIC_API_FN(void, ecsact_set_component_type)
 	ecsact_component_type component_type
 );
 
-ECSACT_DYNAMIC_API_FN(void, ecsact_add_cluster)
+ECSACT_DYNAMIC_API_FN(ecsact_cluster_id, ecsact_create_cluster)
 ( //
 	ecsact_package_id package_id,
 	const char*       cluster_name,
 	int32_t           cluster_name_len
 );
 
-ECSACT_DYNAMIC_API_FN(void, ecsact_add_system_cluster)
+ECSACT_DYNAMIC_API_FN(ecsact_cluster_id, ecsact_create_system_cluster)
 ( //
 	ecsact_system_like_id parent_system_id,
 	const char*           cluster_name,
 	int32_t               cluster_name_len
 );
 
-ECSACT_DYNAMIC_API_FN(void, ecsact_end_cluster)
+ECSACT_DYNAMIC_API_FN(void, ecsact_add_system_to_cluster)
 ( //
-	ecsact_package_id package_id
-);
-
-ECSACT_DYNAMIC_API_FN(void, ecsact_end_system_cluster)
-( //
-	ecsact_system_like_id parent_system_id
+	ecsact_cluster_id     cluster_id,
+	ecsact_system_like_id system_id
 );
 
 /**
@@ -651,10 +647,9 @@ ECSACT_DYNAMIC_API_FN(
 		fn(ecsact_set_system_parallel_execution, __VA_ARGS__);          \
 		fn(ecsact_set_system_notify_component_setting, __VA_ARGS__);    \
 		fn(ecsact_set_component_type, __VA_ARGS__);                     \
-		fn(ecsact_add_cluster, __VA_ARGS__);                            \
-		fn(ecsact_add_system_cluster, __VA_ARGS__);                     \
-		fn(ecsact_end_cluster, __VA_ARGS__);                            \
-		fn(ecsact_end_system_cluster, __VA_ARGS__);                     \
+		fn(ecsact_create_cluster, __VA_ARGS__);                         \
+		fn(ecsact_create_system_cluster, __VA_ARGS__);                  \
+		fn(ecsact_add_system_to_cluster, __VA_ARGS__);                  \
 		fn(ecsact_check_execution_batches, __VA_ARGS__);                \
 		fn(ecsact_check_system_execution_batches, __VA_ARGS__)
 #endif

--- a/ecsact_runtime/ecsact/runtime/dynamic.h
+++ b/ecsact_runtime/ecsact/runtime/dynamic.h
@@ -544,6 +544,55 @@ ECSACT_DYNAMIC_API_FN(void, ecsact_set_component_type)
 	ecsact_component_type component_type
 );
 
+ECSACT_DYNAMIC_API_FN(void, ecsact_add_cluster)
+( //
+	ecsact_package_id package_id,
+	const char*       cluster_name,
+	int32_t           cluster_name_len
+);
+
+ECSACT_DYNAMIC_API_FN(void, ecsact_add_system_cluster)
+( //
+	ecsact_system_like_id parent_system_id,
+	const char*           cluster_name,
+	int32_t               cluster_name_len
+);
+
+ECSACT_DYNAMIC_API_FN(void, ecsact_end_cluster)
+( //
+	ecsact_package_id package_id
+);
+
+ECSACT_DYNAMIC_API_FN(void, ecsact_end_system_cluster)
+( //
+	ecsact_system_like_id parent_system_id
+);
+
+/**
+ * Validates the explicit clusters. If a cluster contains systems that conflict
+ * then the system ID of the system that causes the conflict is returned.
+ *
+ * @returns invalid system ID or (ecsact_system_like_id)-1 if all clusters are
+ *          valid.
+ */
+ECSACT_DYNAMIC_API_FN(ecsact_system_like_id, ecsact_check_execution_batches)
+( //
+	ecsact_package_id package_id
+);
+
+/**
+ * Validates the explicit clusters for a system.
+ *
+ * @see ecsact_check_execution_batches
+ */
+ECSACT_DYNAMIC_API_FN(
+	ecsact_system_like_id,
+	ecsact_check_system_execution_batches
+)
+( //
+	ecsact_system_like_id system_id
+);
+
 // # BEGIN FOR_EACH_ECSACT_DYNAMIC_API_FN
 #ifdef ECSACT_MSVC_TRADITIONAL
 #	define FOR_EACH_ECSACT_DYNAMIC_API_FN(fn, ...) \
@@ -601,7 +650,13 @@ ECSACT_DYNAMIC_API_FN(void, ecsact_set_component_type)
 		fn(ecsact_set_entity_execution_status, __VA_ARGS__);            \
 		fn(ecsact_set_system_parallel_execution, __VA_ARGS__);          \
 		fn(ecsact_set_system_notify_component_setting, __VA_ARGS__);    \
-		fn(ecsact_set_component_type, __VA_ARGS__)
+		fn(ecsact_set_component_type, __VA_ARGS__);                     \
+		fn(ecsact_add_cluster, __VA_ARGS__);                            \
+		fn(ecsact_add_system_cluster, __VA_ARGS__);                     \
+		fn(ecsact_end_cluster, __VA_ARGS__);                            \
+		fn(ecsact_end_system_cluster, __VA_ARGS__);                     \
+		fn(ecsact_check_execution_batches, __VA_ARGS__);                \
+		fn(ecsact_check_system_execution_batches, __VA_ARGS__)
 #endif
 
 #endif // ECSACT_RUNTIME_DYNAMIC_H

--- a/ecsact_runtime/ecsact/runtime/meta.h
+++ b/ecsact_runtime/ecsact/runtime/meta.h
@@ -551,16 +551,6 @@ ECSACT_META_API_FN(void, ecsact_meta_get_system_execution_batch)
 	int32_t*               out_systems_count
 );
 
-ECSACT_META_API_FN(ecsact_system_like_id, ecsact_meta_check_execution_batches)
-( //
-	ecsact_package_id package_id
-);
-
-ECSACT_META_API_FN(ecsact_system_like_id, ecsact_meta_check_system_execution_batches)
-( //
-	ecsact_system_like_id system_id
-);
-
 ECSACT_META_API_FN(bool, ecsact_meta_is_system)
 ( //
 	ecsact_system_like_id system_id
@@ -569,30 +559,6 @@ ECSACT_META_API_FN(bool, ecsact_meta_is_system)
 ECSACT_META_API_FN(bool, ecsact_meta_is_action)
 ( //
 	ecsact_system_like_id system_id
-);
-
-ECSACT_META_API_FN(void, ecsact_meta_add_cluster)
-( //
-	ecsact_package_id package_id,
-	const char*       cluster_name,
-	int32_t           cluster_name_len
-);
-
-ECSACT_META_API_FN(void, ecsact_meta_add_system_cluster)
-( //
-	ecsact_system_like_id parent_system_id,
-	const char*           cluster_name,
-	int32_t               cluster_name_len
-);
-
-ECSACT_META_API_FN(void, ecsact_meta_end_cluster)
-( //
-	ecsact_package_id package_id
-);
-
-ECSACT_META_API_FN(void, ecsact_meta_end_system_cluster)
-( //
-	ecsact_system_like_id parent_system_id
 );
 
 // # BEGIN FOR_EACH_ECSACT_META_API_FN
@@ -665,14 +631,8 @@ ECSACT_META_API_FN(void, ecsact_meta_end_system_cluster)
 		fn(ecsact_meta_get_execution_batch, __VA_ARGS__);                   \
 		fn(ecsact_meta_count_system_execution_batches, __VA_ARGS__);        \
 		fn(ecsact_meta_get_system_execution_batch, __VA_ARGS__);            \
-		fn(ecsact_meta_check_execution_batches, __VA_ARGS__);               \
-		fn(ecsact_meta_check_system_execution_batches, __VA_ARGS__);        \
 		fn(ecsact_meta_is_system, __VA_ARGS__);                             \
-		fn(ecsact_meta_is_action, __VA_ARGS__);                             \
-		fn(ecsact_meta_add_cluster, __VA_ARGS__);                           \
-		fn(ecsact_meta_add_system_cluster, __VA_ARGS__);                    \
-		fn(ecsact_meta_end_cluster, __VA_ARGS__);                           \
-		fn(ecsact_meta_end_system_cluster, __VA_ARGS__)
+		fn(ecsact_meta_is_action, __VA_ARGS__)
 #endif
 
 #endif // ECSACT_RUNTIME_META_H

--- a/ecsact_runtime/ecsact/runtime/meta.h
+++ b/ecsact_runtime/ecsact/runtime/meta.h
@@ -551,6 +551,16 @@ ECSACT_META_API_FN(void, ecsact_meta_get_system_execution_batch)
 	int32_t*               out_systems_count
 );
 
+ECSACT_META_API_FN(ecsact_system_like_id, ecsact_meta_check_execution_batches)
+( //
+	ecsact_package_id package_id
+);
+
+ECSACT_META_API_FN(ecsact_system_like_id, ecsact_meta_check_system_execution_batches)
+( //
+	ecsact_system_like_id system_id
+);
+
 ECSACT_META_API_FN(bool, ecsact_meta_is_system)
 ( //
 	ecsact_system_like_id system_id
@@ -655,6 +665,8 @@ ECSACT_META_API_FN(void, ecsact_meta_end_system_cluster)
 		fn(ecsact_meta_get_execution_batch, __VA_ARGS__);                   \
 		fn(ecsact_meta_count_system_execution_batches, __VA_ARGS__);        \
 		fn(ecsact_meta_get_system_execution_batch, __VA_ARGS__);            \
+		fn(ecsact_meta_check_execution_batches, __VA_ARGS__);               \
+		fn(ecsact_meta_check_system_execution_batches, __VA_ARGS__);        \
 		fn(ecsact_meta_is_system, __VA_ARGS__);                             \
 		fn(ecsact_meta_is_action, __VA_ARGS__);                             \
 		fn(ecsact_meta_add_cluster, __VA_ARGS__);                           \

--- a/ecsact_runtime/ecsact/runtime/meta.h
+++ b/ecsact_runtime/ecsact/runtime/meta.h
@@ -561,6 +561,24 @@ ECSACT_META_API_FN(bool, ecsact_meta_is_action)
 	ecsact_system_like_id system_id
 );
 
+ECSACT_META_API_FN(const char*, ecsact_meta_cluster_name)
+( //
+	ecsact_cluster_id cluster_id
+);
+
+ECSACT_META_API_FN(int32_t, ecsact_meta_count_cluster_systems)
+( //
+	ecsact_cluster_id cluster_id
+);
+
+ECSACT_META_API_FN(void, ecsact_meta_get_cluster_systems)
+( //
+	ecsact_cluster_id      cluster_id,
+	int32_t                max_systems_count,
+	ecsact_system_like_id* out_systems,
+	int32_t*               out_systems_count
+);
+
 // # BEGIN FOR_EACH_ECSACT_META_API_FN
 #ifdef ECSACT_MSVC_TRADITIONAL
 #	define FOR_EACH_ECSACT_META_API_FN(fn, ...) ECSACT_MSVC_TRADITIONAL_ERROR()
@@ -632,7 +650,10 @@ ECSACT_META_API_FN(bool, ecsact_meta_is_action)
 		fn(ecsact_meta_count_system_execution_batches, __VA_ARGS__);        \
 		fn(ecsact_meta_get_system_execution_batch, __VA_ARGS__);            \
 		fn(ecsact_meta_is_system, __VA_ARGS__);                             \
-		fn(ecsact_meta_is_action, __VA_ARGS__)
+		fn(ecsact_meta_is_action, __VA_ARGS__);                             \
+		fn(ecsact_meta_cluster_name, __VA_ARGS__);                          \
+		fn(ecsact_meta_count_cluster_systems, __VA_ARGS__);                 \
+		fn(ecsact_meta_get_cluster_systems, __VA_ARGS__)
 #endif
 
 #endif // ECSACT_RUNTIME_META_H

--- a/ecsact_runtime/ecsact/runtime/meta.h
+++ b/ecsact_runtime/ecsact/runtime/meta.h
@@ -561,6 +561,30 @@ ECSACT_META_API_FN(bool, ecsact_meta_is_action)
 	ecsact_system_like_id system_id
 );
 
+ECSACT_META_API_FN(void, ecsact_meta_add_cluster)
+( //
+	ecsact_package_id package_id,
+	const char*       cluster_name,
+	int32_t           cluster_name_len
+);
+
+ECSACT_META_API_FN(void, ecsact_meta_add_system_cluster)
+( //
+	ecsact_system_like_id parent_system_id,
+	const char*           cluster_name,
+	int32_t               cluster_name_len
+);
+
+ECSACT_META_API_FN(void, ecsact_meta_end_cluster)
+( //
+	ecsact_package_id package_id
+);
+
+ECSACT_META_API_FN(void, ecsact_meta_end_system_cluster)
+( //
+	ecsact_system_like_id parent_system_id
+);
+
 // # BEGIN FOR_EACH_ECSACT_META_API_FN
 #ifdef ECSACT_MSVC_TRADITIONAL
 #	define FOR_EACH_ECSACT_META_API_FN(fn, ...) ECSACT_MSVC_TRADITIONAL_ERROR()
@@ -632,7 +656,11 @@ ECSACT_META_API_FN(bool, ecsact_meta_is_action)
 		fn(ecsact_meta_count_system_execution_batches, __VA_ARGS__);        \
 		fn(ecsact_meta_get_system_execution_batch, __VA_ARGS__);            \
 		fn(ecsact_meta_is_system, __VA_ARGS__);                             \
-		fn(ecsact_meta_is_action, __VA_ARGS__)
+		fn(ecsact_meta_is_action, __VA_ARGS__);                             \
+		fn(ecsact_meta_add_cluster, __VA_ARGS__);                           \
+		fn(ecsact_meta_add_system_cluster, __VA_ARGS__);                    \
+		fn(ecsact_meta_end_cluster, __VA_ARGS__);                           \
+		fn(ecsact_meta_end_system_cluster, __VA_ARGS__)
 #endif
 
 #endif // ECSACT_RUNTIME_META_H

--- a/ecsact_runtime/ecsact/runtime/meta.hh
+++ b/ecsact_runtime/ecsact/runtime/meta.hh
@@ -364,15 +364,32 @@ ECSACT_ALWAYS_INLINE std::vector<ecsact_system_id> get_child_system_ids(
 	SystemLikeID id
 ) {
 	auto system_like_id = ecsact_id_cast<ecsact_system_like_id>(id);
-	std::vector<ecsact_system_id> child_system_ids;
-	child_system_ids.resize(ecsact_meta_count_child_systems(system_like_id));
-	ecsact_meta_get_child_system_ids(
-		system_like_id,
-		static_cast<int32_t>(child_system_ids.size()),
-		child_system_ids.data(),
-		nullptr
-	);
-	return child_system_ids;
+	std::vector<ecsact_system_id> result;
+	auto batch_count = ecsact_meta_count_system_execution_batches(system_like_id);
+	for(int32_t i = 0; batch_count > i; ++i) {
+		int32_t systems_count = 0;
+		ecsact_meta_get_system_execution_batch(
+			system_like_id,
+			i,
+			0,
+			nullptr,
+			&systems_count
+		);
+		std::vector<ecsact_system_like_id> batch_systems(systems_count);
+		ecsact_meta_get_system_execution_batch(
+			system_like_id,
+			i,
+			systems_count,
+			batch_systems.data(),
+			nullptr
+		);
+		for(auto sys_id : batch_systems) {
+			if(ecsact_meta_is_system(sys_id)) {
+				result.push_back(static_cast<ecsact_system_id>(sys_id));
+			}
+		}
+	}
+	return result;
 }
 
 ECSACT_ALWAYS_INLINE std::optional<ecsact_system_like_id> get_parent_system_id(
@@ -388,15 +405,22 @@ ECSACT_ALWAYS_INLINE std::optional<ecsact_system_like_id> get_parent_system_id(
 ECSACT_ALWAYS_INLINE std::vector<ecsact_system_like_id> get_top_level_systems(
 	ecsact_package_id package_id
 ) {
-	std::vector<ecsact_system_like_id> top_sys_like_ids;
-	top_sys_like_ids.resize(ecsact_meta_count_top_level_systems(package_id));
-	ecsact_meta_get_top_level_systems(
-		package_id,
-		static_cast<int32_t>(top_sys_like_ids.size()),
-		top_sys_like_ids.data(),
-		nullptr
-	);
-	return top_sys_like_ids;
+	std::vector<ecsact_system_like_id> result;
+	auto batch_count = ecsact_meta_count_execution_batches(package_id);
+	for(int32_t i = 0; batch_count > i; ++i) {
+		int32_t systems_count = 0;
+		ecsact_meta_get_execution_batch(package_id, i, 0, nullptr, &systems_count);
+		std::vector<ecsact_system_like_id> batch_systems(systems_count);
+		ecsact_meta_get_execution_batch(
+			package_id,
+			i,
+			systems_count,
+			batch_systems.data(),
+			nullptr
+		);
+		result.insert(result.end(), batch_systems.begin(), batch_systems.end());
+	}
+	return result;
 }
 
 ECSACT_ALWAYS_INLINE auto get_all_system_like_ids(


### PR DESCRIPTION
You can now wrap systems in `cluster { ... }` syntax. This comes with additional improvements on the cluster detection which was previously not properly considering `include` and `exclude` capabilities.