### PR TITLE
fix: parse resolver runtime reset for lsp

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,7 +4,7 @@ root = true
 end_of_line = lf
 insert_final_newline = true
 
-[*.{cc,hh,cpp,hpp}]
+[*.{cc,hh,cpp,hpp,h}]
 # matching .clang-format IndentWidth
 indent_size = 2
 

--- a/ecsact_interpret/parse-resolver-runtime/lifecycle.cc
+++ b/ecsact_interpret/parse-resolver-runtime/lifecycle.cc
@@ -128,3 +128,11 @@ auto ecsact::interpret::details::trigger_on_destroy( //
 		}
 	}
 }
+
+auto ecsact::interpret::details::reset_lifecycle() -> void {
+	for(auto& info : lifecycle_info) {
+		info.last_event_ref_id = {};
+		info.callback_id.clear();
+		info.callbacks.clear();
+	}
+}

--- a/ecsact_interpret/parse-resolver-runtime/lifecycle.hh
+++ b/ecsact_interpret/parse-resolver-runtime/lifecycle.hh
@@ -43,6 +43,8 @@ auto on_destroy( //
 
 auto trigger_on_destroy(destroyable_id_t id) -> void;
 
+auto reset_lifecycle() -> void;
+
 class event_ref {
 	friend auto on_destroy(castable_destroyable_ids_t, std::function<void()>)
 		-> event_ref;

--- a/ecsact_interpret/parse-resolver-runtime/parse-resolver-runtime.cc
+++ b/ecsact_interpret/parse-resolver-runtime/parse-resolver-runtime.cc
@@ -16,6 +16,7 @@
 #include "ecsact_interpret/parse-resolver-runtime/lifecycle.hh"
 
 using ecsact::interpret::details::trigger_on_destroy;
+using ecsact::interpret::details::reset_lifecycle;
 
 template<typename T, typename... Ts>
 struct is_any : std::disjunction<std::is_same<T, Ts>...> {};
@@ -152,6 +153,21 @@ static std::unordered_map<ecsact_action_id, action_def>      act_defs;
 static std::unordered_map<ecsact_enum_id, enum_def>          enum_defs;
 static std::unordered_map<ecsact_cluster_id, cluster_def>    cluster_defs;
 static std::optional<ecsact_package_id>                      main_package_id;
+
+void ecsact_interpret_reset() {
+	last_id = 0;
+	full_names.clear();
+	package_defs.clear();
+	def_owner_map.clear();
+	comp_defs.clear();
+	trans_defs.clear();
+	sys_defs.clear();
+	act_defs.clear();
+	enum_defs.clear();
+	cluster_defs.clear();
+	main_package_id = std::nullopt;
+	reset_lifecycle();
+}
 
 template<typename T>
 static ecsact_package_id owner_package_id(T id) {

--- a/ecsact_interpret/parse-resolver-runtime/parse-resolver-runtime.cc
+++ b/ecsact_interpret/parse-resolver-runtime/parse-resolver-runtime.cc
@@ -15,8 +15,8 @@
 #include <unordered_set>
 #include "ecsact_interpret/parse-resolver-runtime/lifecycle.hh"
 
-using ecsact::interpret::details::trigger_on_destroy;
 using ecsact::interpret::details::reset_lifecycle;
+using ecsact::interpret::details::trigger_on_destroy;
 
 template<typename T, typename... Ts>
 struct is_any : std::disjunction<std::is_same<T, Ts>...> {};

--- a/ecsact_lsp_server/details/workspace_manager.hh
+++ b/ecsact_lsp_server/details/workspace_manager.hh
@@ -58,9 +58,6 @@ struct document_state {
 	std::vector<ecsact_parse_status> parse_statuses;
 	std::string                      full_text;
 	std::string_view                 next_parse_view;
-
-	// Legacy for compatibility during transition
-	std::vector<std::vector<ecsact_statement>> parse_stacks;
 };
 
 struct workspace_state {
@@ -102,32 +99,31 @@ inline auto get_source_range(
 inline auto builtin_type_name(ecsact_builtin_type type) -> std::string {
 	switch(type) {
 		case ECSACT_BOOL:
-			return ECSACT_PARSE_KW_BOOL;
+			return std::string(ECSACT_PARSE_KW_BOOL);
 		case ECSACT_I8:
-			return ECSACT_PARSE_KW_I8;
+			return std::string(ECSACT_PARSE_KW_I8);
 		case ECSACT_U8:
-			return ECSACT_PARSE_KW_U8;
+			return std::string(ECSACT_PARSE_KW_U8);
 		case ECSACT_I16:
-			return ECSACT_PARSE_KW_I16;
+			return std::string(ECSACT_PARSE_KW_I16);
 		case ECSACT_U16:
-			return ECSACT_PARSE_KW_U16;
+			return std::string(ECSACT_PARSE_KW_U16);
 		case ECSACT_I32:
-			return ECSACT_PARSE_KW_I32;
+			return std::string(ECSACT_PARSE_KW_I32);
 		case ECSACT_U32:
-			return ECSACT_PARSE_KW_U32;
+			return std::string(ECSACT_PARSE_KW_U32);
 		case ECSACT_F32:
-			return ECSACT_PARSE_KW_F32;
+			return std::string(ECSACT_PARSE_KW_F32);
 		case ECSACT_I64:
-			return ECSACT_PARSE_KW_I64;
+			return std::string(ECSACT_PARSE_KW_I64);
 		case ECSACT_U64:
-			return ECSACT_PARSE_KW_U64;
+			return std::string(ECSACT_PARSE_KW_U64);
 		case ECSACT_F64:
-			return ECSACT_PARSE_KW_F64;
+			return std::string(ECSACT_PARSE_KW_F64);
 		case ECSACT_ENTITY_TYPE:
-			return ECSACT_PARSE_KW_ENTITY;
+			return std::string(ECSACT_PARSE_KW_ENTITY);
 	}
-	return "unknown builtin type (" + std::to_string(static_cast<int>(type)) +
-		")";
+	return "unknown builtin type (" + std::to_string(static_cast<int>(type)) + ")";
 }
 
 template<typename E>
@@ -269,7 +265,6 @@ class workspace_manager {
 
 	auto _parse_document(std::string uri, int version, document_state& doc) {
 		doc.stacks.clear();
-		doc.parse_stacks.clear();
 		doc.parse_statuses.clear();
 
 		auto diagnostics = std::vector<diagnostic>{};
@@ -305,7 +300,6 @@ class workspace_manager {
 			);
 
 			doc.stacks.push_back({.stack = stack, .range = stack_range});
-			doc.parse_stacks.push_back(stack);
 
 			if(!ecsact_is_error_parse_status_code(status.code)) {
 				auto& statement = stack.back();
@@ -354,7 +348,7 @@ class workspace_manager {
 		using std::views::drop;
 		using namespace std::string_literals;
 
-		if(doc.parse_stacks.empty()) {
+		if(doc.stacks.empty()) {
 			return;
 		}
 
@@ -364,13 +358,13 @@ class workspace_manager {
 		}
 
 		auto  diagnostics = std::vector<diagnostic>{};
-		auto& package_parse_stack = doc.parse_stacks.front();
+		auto& package_stack_info = doc.stacks.front();
 
-		if(package_parse_stack.empty()) {
+		if(package_stack_info.stack.empty()) {
 			return;
 		}
 
-		auto& package_statement = package_parse_stack.front();
+		auto& package_statement = package_stack_info.stack.front();
 
 		if(package_statement.type != ECSACT_STATEMENT_PACKAGE) {
 			diagnostics.push_back(
@@ -392,9 +386,9 @@ class workspace_manager {
 			auto system_ranges = std::unordered_map<ecsact_system_like_id, range>{};
 
 			// Evaluate all statements in stacks except first (package)
-			for(size_t stack_idx = 1; stack_idx < doc.parse_stacks.size();
-					++stack_idx) {
-				auto& parse_stack = doc.parse_stacks[stack_idx];
+			for(size_t stack_idx = 1; stack_idx < doc.stacks.size(); ++stack_idx) {
+				auto& info = doc.stacks[stack_idx];
+				auto& parse_stack = info.stack;
 				auto& status = doc.parse_statuses[stack_idx];
 
 				for(auto idx = 0; parse_stack.size() > idx; ++idx) {
@@ -913,66 +907,63 @@ public:
 					}
 				}
 
-				auto add_batch_info =
-					[&](auto package_or_sys_id, int32_t i, bool is_sys) {
-						int32_t                            systems_count = 0;
-						std::vector<ecsact_system_like_id> systems;
-						int32_t                            max_systems = 256;
-						systems.resize(max_systems);
-						if(is_sys) {
-							ecsact_meta_get_system_execution_batch(
-								static_cast<ecsact_system_like_id>(package_or_sys_id),
-								i,
-								max_systems,
-								systems.data(),
-								&systems_count
-							);
-						} else {
-							ecsact_meta_get_execution_batch(
-								static_cast<ecsact_package_id>(package_or_sys_id),
-								i,
-								max_systems,
-								systems.data(),
-								&systems_count
-							);
+				auto add_batch_info = [&](auto package_or_sys_id, int32_t i, bool is_sys) {
+					int32_t                            systems_count = 0;
+					std::vector<ecsact_system_like_id> systems;
+					int32_t                            max_systems = 256;
+					systems.resize(max_systems);
+					if(is_sys) {
+						ecsact_meta_get_system_execution_batch(
+							static_cast<ecsact_system_like_id>(package_or_sys_id),
+							i,
+							max_systems,
+							systems.data(),
+							&systems_count
+						);
+					} else {
+						ecsact_meta_get_execution_batch(
+							static_cast<ecsact_package_id>(package_or_sys_id),
+							i,
+							max_systems,
+							systems.data(),
+							&systems_count
+						);
+					}
+					bool in_batch = false;
+					for(int32_t j = 0; systems_count > j; ++j) {
+						if(static_cast<int32_t>(systems[j]) == static_cast<int32_t>(sys_like_id)) {
+							in_batch = true;
 						}
-						bool in_batch = false;
+					}
+
+					if(in_batch) {
+						hover_text += std::format("\n**Execution Batch {} systems:**\n", i);
 						for(int32_t j = 0; systems_count > j; ++j) {
-							if(systems[j] == sys_like_id) {
-								in_batch = true;
-								break;
-							}
-						}
-
-						if(in_batch) {
-							hover_text +=
-								std::format("\n**Execution Batch {} systems:**\n", i);
-							for(int32_t j = 0; systems_count > j; ++j) {
-								auto other_sys_id = systems[j];
-								auto other_name =
-									get_full_name(static_cast<int32_t>(other_sys_id));
-								if(other_name.empty()) {
-									if(ecsact_meta_is_system(other_sys_id)) {
-										other_name = ecsact_meta_system_name(
-											static_cast<ecsact_system_id>(other_sys_id)
-										);
-									} else if(ecsact_meta_is_action(other_sys_id)) {
-										other_name = ecsact_meta_action_name(
-											static_cast<ecsact_action_id>(other_sys_id)
-										);
-									}
-								}
-
-								if(other_sys_id == sys_like_id) {
-									hover_text += std::format(" - **`{}`** (this)\n", other_name);
-								} else {
-									hover_text += std::format(" - `{}`\n", other_name);
+							auto other_sys_id = systems[j];
+							auto other_name =
+								get_full_name(static_cast<int32_t>(other_sys_id));
+							if(other_name.empty()) {
+								if(ecsact_meta_is_system(other_sys_id)) {
+									other_name = ecsact_meta_system_name(
+										static_cast<ecsact_system_id>(other_sys_id)
+									);
+								} else if(ecsact_meta_is_action(other_sys_id)) {
+									other_name = ecsact_meta_action_name(
+										static_cast<ecsact_action_id>(other_sys_id)
+									);
 								}
 							}
-							return true;
+
+							if(static_cast<int32_t>(other_sys_id) == static_cast<int32_t>(sys_like_id)) {
+								hover_text += std::format(" - **`{}`** (this)\n", other_name);
+							} else {
+								hover_text += std::format(" - `{}`\n", other_name);
+							}
 						}
-						return false;
-					};
+						return true;
+					}
+					return false;
+				};
 
 				for(auto package_id : packages) {
 					int32_t batch_count = ecsact_meta_count_execution_batches(package_id);
@@ -986,14 +977,9 @@ public:
 					}
 
 					// Also check nested system execution batches
-					int32_t sys_count = ecsact_meta_count_systems(package_id);
+					int32_t              sys_count = ecsact_meta_count_systems(package_id);
 					std::vector<ecsact_system_id> sys_ids(sys_count);
-					ecsact_meta_get_system_ids(
-						package_id,
-						sys_count,
-						sys_ids.data(),
-						&sys_count
-					);
+					ecsact_meta_get_system_ids(package_id, sys_count, sys_ids.data(), &sys_count);
 					for(auto sys_id : sys_ids) {
 						int32_t s_batch_count = ecsact_meta_count_system_execution_batches(
 							static_cast<ecsact_system_like_id>(sys_id)
@@ -1262,17 +1248,14 @@ public:
 				last_was_space = false;
 			}
 		}
-		// Don't count the word we are currently typing as a "full word before"
-		// unless there is a space after it.
 
 		// What is the word immediately before the cursor?
 		std::string word_at_cursor;
 		if(pos.character > 0 && pos.character <= current_line.size()) {
 			auto start = pos.character;
-			while(start > 0 &&
-						(std::isalnum(current_line[start - 1]) ||
-						 current_line[start - 1] == '_' ||
-						 current_line[start - 1] == '.')) {
+			while(start > 0 && (std::isalnum(current_line[start - 1]) ||
+													current_line[start - 1] == '_' ||
+													current_line[start - 1] == '.')) {
 				start--;
 			}
 			word_at_cursor = current_line.substr(start, pos.character - start);
@@ -1317,49 +1300,6 @@ public:
 			}
 		}
 
-		static const std::vector<std::string> top_level_keywords = {
-			ECSACT_PARSE_KW_MAIN_PACKAGE,
-			ECSACT_PARSE_KW_PACKAGE,
-			ECSACT_PARSE_KW_IMPORT,
-			ECSACT_PARSE_KW_COMPONENT,
-			ECSACT_PARSE_KW_TRANSIENT,
-			ECSACT_PARSE_KW_SYSTEM,
-			ECSACT_PARSE_KW_ACTION,
-			ECSACT_PARSE_KW_ENUM,
-		};
-
-		static const std::vector<std::string> cap_keywords = {
-			ECSACT_PARSE_KW_READONLY,
-			ECSACT_PARSE_KW_READWRITE,
-			ECSACT_PARSE_KW_WRITEONLY,
-			ECSACT_PARSE_KW_ADDS,
-			ECSACT_PARSE_KW_REMOVES,
-			ECSACT_PARSE_KW_EXCLUDE,
-			ECSACT_PARSE_KW_INCLUDE,
-			ECSACT_PARSE_KW_REQUIRED,
-			ECSACT_PARSE_KW_GENERATES,
-		};
-
-		static const std::vector<std::string> generates_keywords = {
-			ECSACT_PARSE_KW_REQUIRED,
-			ECSACT_PARSE_KW_OPTIONAL,
-		};
-
-		static const std::vector<std::string> type_keywords = {
-			ECSACT_PARSE_KW_BOOL,
-			ECSACT_PARSE_KW_I8,
-			ECSACT_PARSE_KW_U8,
-			ECSACT_PARSE_KW_I16,
-			ECSACT_PARSE_KW_U16,
-			ECSACT_PARSE_KW_I32,
-			ECSACT_PARSE_KW_U32,
-			ECSACT_PARSE_KW_I64,
-			ECSACT_PARSE_KW_U64,
-			ECSACT_PARSE_KW_F32,
-			ECSACT_PARSE_KW_F64,
-			ECSACT_PARSE_KW_ENTITY,
-		};
-
 		if(trimmed_before.starts_with(ECSACT_PARSE_KW_IMPORT)) {
 			std::set<std::string> package_names;
 			for(auto& [d_uri, d_state] : _documents) {
@@ -1384,6 +1324,49 @@ public:
 				});
 			}
 		} else {
+			static const std::vector<std::string> top_level_keywords = {
+				ECSACT_PARSE_KW_MAIN_PACKAGE,
+				ECSACT_PARSE_KW_PACKAGE,
+				ECSACT_PARSE_KW_IMPORT,
+				ECSACT_PARSE_KW_COMPONENT,
+				ECSACT_PARSE_KW_TRANSIENT,
+				ECSACT_PARSE_KW_SYSTEM,
+				ECSACT_PARSE_KW_ACTION,
+				ECSACT_PARSE_KW_ENUM,
+			};
+
+			static const std::vector<std::string> cap_keywords = {
+				ECSACT_PARSE_KW_READONLY,
+				ECSACT_PARSE_KW_READWRITE,
+				ECSACT_PARSE_KW_WRITEONLY,
+				ECSACT_PARSE_KW_ADDS,
+				ECSACT_PARSE_KW_REMOVES,
+				ECSACT_PARSE_KW_EXCLUDE,
+				ECSACT_PARSE_KW_INCLUDE,
+				ECSACT_PARSE_KW_REQUIRED,
+				ECSACT_PARSE_KW_GENERATES,
+			};
+
+			static const std::vector<std::string> generates_keywords = {
+				ECSACT_PARSE_KW_REQUIRED,
+				ECSACT_PARSE_KW_OPTIONAL,
+			};
+
+			static const std::vector<std::string> type_keywords = {
+				ECSACT_PARSE_KW_BOOL,
+				ECSACT_PARSE_KW_I8,
+				ECSACT_PARSE_KW_U8,
+				ECSACT_PARSE_KW_I16,
+				ECSACT_PARSE_KW_U16,
+				ECSACT_PARSE_KW_I32,
+				ECSACT_PARSE_KW_U32,
+				ECSACT_PARSE_KW_I64,
+				ECSACT_PARSE_KW_U64,
+				ECSACT_PARSE_KW_F32,
+				ECSACT_PARSE_KW_F64,
+				ECSACT_PARSE_KW_ENTITY,
+			};
+
 			// Keyword suggestions - only if we are at the start of the line or
 			// haven't finished a keyword
 			if(word_count_before == 0) {
@@ -1421,7 +1404,7 @@ public:
 					for(auto const& kw : type_keywords) {
 						result.items.push_back({
 							.label = kw,
-							.kind = completion_item_kind::keyword,
+							.kind = completion_item_kind::class_kind,
 						});
 					}
 				}
@@ -1477,9 +1460,7 @@ public:
 							 stmt.type == ECSACT_STATEMENT_TRANSIENT) {
 							auto name = (stmt.type == ECSACT_STATEMENT_COMPONENT)
 								? get_name_from_sv(stmt.data.component_statement.component_name)
-								: get_name_from_sv(
-										stmt.data.transient_statement.transient_name
-									);
+								: get_name_from_sv(stmt.data.transient_statement.transient_name);
 
 							if(filter_pkg.empty()) {
 								component_names.insert(name);
@@ -1556,10 +1537,8 @@ public:
 			);
 		} else if(statement.type == ECSACT_STATEMENT_ENTITY_CONSTRAINT) {
 			symbol_name = std::string(
-				statement.data.entity_constraint_statement.constraint_component_name
-					.data,
-				statement.data.entity_constraint_statement.constraint_component_name
-					.length
+				statement.data.entity_constraint_statement.constraint_component_name.data,
+				statement.data.entity_constraint_statement.constraint_component_name.length
 			);
 		} else if(statement.type == ECSACT_STATEMENT_SYSTEM_NOTIFY_COMPONENT) {
 			symbol_name = std::string(
@@ -1616,9 +1595,7 @@ public:
 							}
 							auto& d_stmt2 = info2.stack.front();
 							if(d_stmt2.type == ECSACT_STATEMENT_PACKAGE) {
-								if(get_name_from_sv(
-										 d_stmt2.data.package_statement.package_name
-									 ) == prefix) {
+								if(get_name_from_sv(d_stmt2.data.package_statement.package_name) == prefix) {
 									pkg_match = true;
 									break;
 								}

--- a/ecsact_lsp_server/details/workspace_manager.hh
+++ b/ecsact_lsp_server/details/workspace_manager.hh
@@ -99,31 +99,32 @@ inline auto get_source_range(
 inline auto builtin_type_name(ecsact_builtin_type type) -> std::string {
 	switch(type) {
 		case ECSACT_BOOL:
-			return std::string(ECSACT_PARSE_KW_BOOL);
+			return ECSACT_PARSE_KW_BOOL;
 		case ECSACT_I8:
-			return std::string(ECSACT_PARSE_KW_I8);
+			return ECSACT_PARSE_KW_I8;
 		case ECSACT_U8:
-			return std::string(ECSACT_PARSE_KW_U8);
+			return ECSACT_PARSE_KW_U8;
 		case ECSACT_I16:
-			return std::string(ECSACT_PARSE_KW_I16);
+			return ECSACT_PARSE_KW_I16;
 		case ECSACT_U16:
-			return std::string(ECSACT_PARSE_KW_U16);
+			return ECSACT_PARSE_KW_U16;
 		case ECSACT_I32:
-			return std::string(ECSACT_PARSE_KW_I32);
+			return ECSACT_PARSE_KW_I32;
 		case ECSACT_U32:
-			return std::string(ECSACT_PARSE_KW_U32);
+			return ECSACT_PARSE_KW_U32;
 		case ECSACT_F32:
-			return std::string(ECSACT_PARSE_KW_F32);
+			return ECSACT_PARSE_KW_F32;
 		case ECSACT_I64:
-			return std::string(ECSACT_PARSE_KW_I64);
+			return ECSACT_PARSE_KW_I64;
 		case ECSACT_U64:
-			return std::string(ECSACT_PARSE_KW_U64);
+			return ECSACT_PARSE_KW_U64;
 		case ECSACT_F64:
-			return std::string(ECSACT_PARSE_KW_F64);
+			return ECSACT_PARSE_KW_F64;
 		case ECSACT_ENTITY_TYPE:
-			return std::string(ECSACT_PARSE_KW_ENTITY);
+			return ECSACT_PARSE_KW_ENTITY;
 	}
-	return "unknown builtin type (" + std::to_string(static_cast<int>(type)) + ")";
+
+	return std::format("unknown builtin type ({})", static_cast<int>(type));
 }
 
 template<typename E>
@@ -907,63 +908,67 @@ public:
 					}
 				}
 
-				auto add_batch_info = [&](auto package_or_sys_id, int32_t i, bool is_sys) {
-					int32_t                            systems_count = 0;
-					std::vector<ecsact_system_like_id> systems;
-					int32_t                            max_systems = 256;
-					systems.resize(max_systems);
-					if(is_sys) {
-						ecsact_meta_get_system_execution_batch(
-							static_cast<ecsact_system_like_id>(package_or_sys_id),
-							i,
-							max_systems,
-							systems.data(),
-							&systems_count
-						);
-					} else {
-						ecsact_meta_get_execution_batch(
-							static_cast<ecsact_package_id>(package_or_sys_id),
-							i,
-							max_systems,
-							systems.data(),
-							&systems_count
-						);
-					}
-					bool in_batch = false;
-					for(int32_t j = 0; systems_count > j; ++j) {
-						if(static_cast<int32_t>(systems[j]) == static_cast<int32_t>(sys_like_id)) {
-							in_batch = true;
+				auto add_batch_info =
+					[&](auto package_or_sys_id, int32_t i, bool is_sys) {
+						int32_t                            systems_count = 0;
+						std::vector<ecsact_system_like_id> systems;
+						int32_t                            max_systems = 256;
+						systems.resize(max_systems);
+						if(is_sys) {
+							ecsact_meta_get_system_execution_batch(
+								static_cast<ecsact_system_like_id>(package_or_sys_id),
+								i,
+								max_systems,
+								systems.data(),
+								&systems_count
+							);
+						} else {
+							ecsact_meta_get_execution_batch(
+								static_cast<ecsact_package_id>(package_or_sys_id),
+								i,
+								max_systems,
+								systems.data(),
+								&systems_count
+							);
 						}
-					}
-
-					if(in_batch) {
-						hover_text += std::format("\n**Execution Batch {} systems:**\n", i);
+						bool in_batch = false;
 						for(int32_t j = 0; systems_count > j; ++j) {
-							auto other_sys_id = systems[j];
-							auto other_name =
-								get_full_name(static_cast<int32_t>(other_sys_id));
-							if(other_name.empty()) {
-								if(ecsact_meta_is_system(other_sys_id)) {
-									other_name = ecsact_meta_system_name(
-										static_cast<ecsact_system_id>(other_sys_id)
-									);
-								} else if(ecsact_meta_is_action(other_sys_id)) {
-									other_name = ecsact_meta_action_name(
-										static_cast<ecsact_action_id>(other_sys_id)
-									);
+							if(static_cast<int32_t>(systems[j]) ==
+								 static_cast<int32_t>(sys_like_id)) {
+								in_batch = true;
+							}
+						}
+
+						if(in_batch) {
+							hover_text +=
+								std::format("\n**Execution Batch {} systems:**\n", i);
+							for(int32_t j = 0; systems_count > j; ++j) {
+								auto other_sys_id = systems[j];
+								auto other_name =
+									get_full_name(static_cast<int32_t>(other_sys_id));
+								if(other_name.empty()) {
+									if(ecsact_meta_is_system(other_sys_id)) {
+										other_name = ecsact_meta_system_name(
+											static_cast<ecsact_system_id>(other_sys_id)
+										);
+									} else if(ecsact_meta_is_action(other_sys_id)) {
+										other_name = ecsact_meta_action_name(
+											static_cast<ecsact_action_id>(other_sys_id)
+										);
+									}
+								}
+
+								if(static_cast<int32_t>(other_sys_id) ==
+									 static_cast<int32_t>(sys_like_id)) {
+									hover_text += std::format(" - **`{}`** (this)\n", other_name);
+								} else {
+									hover_text += std::format(" - `{}`\n", other_name);
 								}
 							}
-
-							if(static_cast<int32_t>(other_sys_id) == static_cast<int32_t>(sys_like_id)) {
-								hover_text += std::format(" - **`{}`** (this)\n", other_name);
-							} else {
-								hover_text += std::format(" - `{}`\n", other_name);
-							}
+							return true;
 						}
-						return true;
-					}
-					return false;
-				};
+						return false;
+					};
 
 				for(auto package_id : packages) {
 					int32_t batch_count = ecsact_meta_count_execution_batches(package_id);
@@ -977,9 +982,14 @@ public:
 					}
 
 					// Also check nested system execution batches
-					int32_t              sys_count = ecsact_meta_count_systems(package_id);
+					int32_t sys_count = ecsact_meta_count_systems(package_id);
 					std::vector<ecsact_system_id> sys_ids(sys_count);
-					ecsact_meta_get_system_ids(package_id, sys_count, sys_ids.data(), &sys_count);
+					ecsact_meta_get_system_ids(
+						package_id,
+						sys_count,
+						sys_ids.data(),
+						&sys_count
+					);
 					for(auto sys_id : sys_ids) {
 						int32_t s_batch_count = ecsact_meta_count_system_execution_batches(
 							static_cast<ecsact_system_like_id>(sys_id)
@@ -1253,9 +1263,10 @@ public:
 		std::string word_at_cursor;
 		if(pos.character > 0 && pos.character <= current_line.size()) {
 			auto start = pos.character;
-			while(start > 0 && (std::isalnum(current_line[start - 1]) ||
-													current_line[start - 1] == '_' ||
-													current_line[start - 1] == '.')) {
+			while(start > 0 &&
+						(std::isalnum(current_line[start - 1]) ||
+						 current_line[start - 1] == '_' ||
+						 current_line[start - 1] == '.')) {
 				start--;
 			}
 			word_at_cursor = current_line.substr(start, pos.character - start);
@@ -1460,7 +1471,9 @@ public:
 							 stmt.type == ECSACT_STATEMENT_TRANSIENT) {
 							auto name = (stmt.type == ECSACT_STATEMENT_COMPONENT)
 								? get_name_from_sv(stmt.data.component_statement.component_name)
-								: get_name_from_sv(stmt.data.transient_statement.transient_name);
+								: get_name_from_sv(
+										stmt.data.transient_statement.transient_name
+									);
 
 							if(filter_pkg.empty()) {
 								component_names.insert(name);
@@ -1537,8 +1550,10 @@ public:
 			);
 		} else if(statement.type == ECSACT_STATEMENT_ENTITY_CONSTRAINT) {
 			symbol_name = std::string(
-				statement.data.entity_constraint_statement.constraint_component_name.data,
-				statement.data.entity_constraint_statement.constraint_component_name.length
+				statement.data.entity_constraint_statement.constraint_component_name
+					.data,
+				statement.data.entity_constraint_statement.constraint_component_name
+					.length
 			);
 		} else if(statement.type == ECSACT_STATEMENT_SYSTEM_NOTIFY_COMPONENT) {
 			symbol_name = std::string(
@@ -1595,7 +1610,9 @@ public:
 							}
 							auto& d_stmt2 = info2.stack.front();
 							if(d_stmt2.type == ECSACT_STATEMENT_PACKAGE) {
-								if(get_name_from_sv(d_stmt2.data.package_statement.package_name) == prefix) {
+								if(get_name_from_sv(
+										 d_stmt2.data.package_statement.package_name
+									 ) == prefix) {
 									pkg_match = true;
 									break;
 								}

--- a/ecsact_lsp_server/details/workspace_manager.hh
+++ b/ecsact_lsp_server/details/workspace_manager.hh
@@ -96,89 +96,12 @@ inline auto get_source_range(
 	return r;
 }
 
-inline auto builtin_type_name(ecsact_builtin_type type) -> std::string {
-	switch(type) {
-		case ECSACT_BOOL:
-			return ECSACT_PARSE_KW_BOOL;
-		case ECSACT_I8:
-			return ECSACT_PARSE_KW_I8;
-		case ECSACT_U8:
-			return ECSACT_PARSE_KW_U8;
-		case ECSACT_I16:
-			return ECSACT_PARSE_KW_I16;
-		case ECSACT_U16:
-			return ECSACT_PARSE_KW_U16;
-		case ECSACT_I32:
-			return ECSACT_PARSE_KW_I32;
-		case ECSACT_U32:
-			return ECSACT_PARSE_KW_U32;
-		case ECSACT_F32:
-			return ECSACT_PARSE_KW_F32;
-		case ECSACT_I64:
-			return ECSACT_PARSE_KW_I64;
-		case ECSACT_U64:
-			return ECSACT_PARSE_KW_U64;
-		case ECSACT_F64:
-			return ECSACT_PARSE_KW_F64;
-		case ECSACT_ENTITY_TYPE:
-			return ECSACT_PARSE_KW_ENTITY;
-	}
-
-	return std::format("unknown builtin type ({})", static_cast<int>(type));
-}
-
 template<typename E>
 inline auto enum_name_safe(E value, std::string fallback) -> std::string {
 	if(magic_enum::enum_cast<E>(value)) {
 		return std::string{magic_enum::enum_name(value)};
 	}
-	return fallback + " (" + std::to_string(static_cast<int>(value)) + ")";
-}
-
-inline auto pretty_statement_type_name(ecsact_statement_type type)
-	-> std::string {
-	switch(type) {
-		case ECSACT_STATEMENT_NONE:
-			return "none";
-		case ECSACT_STATEMENT_UNKNOWN:
-			return "unknown";
-		case ECSACT_STATEMENT_PACKAGE:
-			return "package";
-		case ECSACT_STATEMENT_IMPORT:
-			return "import";
-		case ECSACT_STATEMENT_COMPONENT:
-			return "component";
-		case ECSACT_STATEMENT_TRANSIENT:
-			return "transient";
-		case ECSACT_STATEMENT_SYSTEM:
-			return "system";
-		case ECSACT_STATEMENT_ACTION:
-			return "action";
-		case ECSACT_STATEMENT_ENUM:
-			return "enum";
-		case ECSACT_STATEMENT_ENUM_VALUE:
-			return "enum value";
-		case ECSACT_STATEMENT_BUILTIN_TYPE_FIELD:
-		case ECSACT_STATEMENT_USER_TYPE_FIELD:
-		case ECSACT_STATEMENT_ENTITY_FIELD:
-			return "field";
-		case ECSACT_STATEMENT_SYSTEM_COMPONENT:
-			return "system capability";
-		case ECSACT_STATEMENT_SYSTEM_GENERATES:
-			return "generates";
-		case ECSACT_STATEMENT_SYSTEM_WITH:
-			return "with";
-		case ECSACT_STATEMENT_ENTITY_CONSTRAINT:
-			return "entity constraint";
-		case ECSACT_STATEMENT_SYSTEM_NOTIFY:
-			return "system notify";
-		case ECSACT_STATEMENT_SYSTEM_NOTIFY_COMPONENT:
-			return "system notify component";
-		case ECSACT_STATEMENT_CLUSTER:
-			return "cluster";
-	}
-
-	return enum_name_safe(type, "unknown statement");
+	return std::format("{} ({})", fallback, static_cast<int>(value));
 }
 
 inline auto parse_stack(
@@ -214,13 +137,21 @@ static inline auto create_eval_error_diagnostics(
 	if(err.code == ECSACT_EVAL_ERR_INVALID_CONTEXT) {
 		auto r = get_source_range(doc.full_text, err.relevant_content);
 		auto message = [&]() -> std::string {
+			auto pretty_type_name =
+				ecsact_parse_statement_type_name_pretty(statement.type);
 			if(err.context_type == ECSACT_STATEMENT_NONE) {
-				return pretty_statement_type_name(statement.type) +
-					" is not allowed as a top level statement"s;
+				return std::format(
+					"{} is not allowed as a top level statement",
+					pretty_type_name
+				);
 			} else {
-				return pretty_statement_type_name(statement.type) +
-					" is not allowed in "s +
-					pretty_statement_type_name(err.context_type) + " context";
+				auto context_type_name =
+					ecsact_parse_statement_type_name_pretty(err.context_type);
+				return std::format(
+					"{} is not allowed in {} context",
+					pretty_type_name,
+					context_type_name
+				);
 			}
 		}();
 
@@ -287,18 +218,18 @@ class workspace_manager {
 				}
 			}
 
-			auto current_parse_view = doc.next_parse_view;
-			auto stack_start_ptr = current_parse_view.data();
+			auto  current_parse_view = doc.next_parse_view;
+			auto* stack_start_ptr = current_parse_view.data();
 			doc.next_parse_view = parse_stack(current_parse_view, status, stack);
 
-			auto stack_end_ptr = doc.next_parse_view.data();
-			auto stack_range = get_source_range(
-				doc.full_text,
-				{
-					.data = stack_start_ptr,
-					.length = static_cast<int32_t>(stack_end_ptr - stack_start_ptr),
-				}
-			);
+			auto* stack_end_ptr = doc.next_parse_view.data();
+			auto  stack_range = get_source_range(
+        doc.full_text,
+        ecsact_statement_sv{
+					 .data = stack_start_ptr,
+					 .length = static_cast<int32_t>(stack_end_ptr - stack_start_ptr),
+        }
+      );
 
 			doc.stacks.push_back({.stack = stack, .range = stack_range});
 
@@ -539,7 +470,7 @@ public:
 		_workspaces[ws.uri] = workspace_state{.uri = ws.uri};
 		auto& workspace = _workspaces[ws.uri];
 
-		for(auto const& entry :
+		for(const auto& entry :
 				std::filesystem::recursive_directory_iterator(ws_path)) {
 			if(entry.is_regular_file() && entry.path().extension() == ".ecsact") {
 				auto uri = detail::path_to_uri(entry.path());
@@ -562,7 +493,7 @@ public:
 	auto remove_workspace(workspace_folder ws) -> void {
 		auto it = _workspaces.find(ws.uri);
 		if(it != _workspaces.end()) {
-			for(auto const& doc_uri : it->second.document_uris) {
+			for(const auto& doc_uri : it->second.document_uris) {
 				remove_document(doc_uri);
 			}
 			_workspaces.erase(it);
@@ -881,8 +812,12 @@ public:
 					}
 				}
 			}
-			hover_text +=
-				"### " + pretty_statement_type_name(type) + " `" + name + "`\n";
+
+			hover_text += std::format(
+				"### {} `{}`\n",
+				ecsact_parse_statement_type_name_pretty(type),
+				name
+			);
 
 			if(type == ECSACT_STATEMENT_SYSTEM || type == ECSACT_STATEMENT_ACTION) {
 				auto sys_like_id = static_cast<ecsact_system_like_id>(id);
@@ -1029,11 +964,13 @@ public:
 					}
 				}
 			}
-			auto value_name =
-				get_name_from_sv(statement.data.enum_value_statement.name);
-			hover_text += "### enum value `" + parent_name + "." + value_name + "`\n";
-			hover_text +=
-				std::format("value: `{}`\n", statement.data.enum_value_statement.value);
+
+			hover_text += std::format(
+				"## enum value `{}.{}`\n value: `{}`\n",
+				parent_name,
+				get_name_from_sv(statement.data.enum_value_statement.name),
+				statement.data.enum_value_statement.value
+			);
 		} else if(statement.type == ECSACT_STATEMENT_SYSTEM_COMPONENT ||
 							statement.type == ECSACT_STATEMENT_ENTITY_CONSTRAINT ||
 							statement.type == ECSACT_STATEMENT_SYSTEM_NOTIFY_COMPONENT ||
@@ -1057,8 +994,8 @@ public:
 				);
 			}
 
-			std::string search_name = name;
-			auto        last_dot = search_name.find_last_of('.');
+			auto search_name = name;
+			auto last_dot = search_name.find_last_of('.');
 			if(last_dot != std::string::npos) {
 				search_name = search_name.substr(last_dot + 1);
 			}
@@ -1069,8 +1006,8 @@ public:
 					if(info.stack.empty()) {
 						continue;
 					}
-					auto&       d_stmt = info.stack.back();
-					std::string d_name;
+					auto& d_stmt = info.stack.back();
+					auto  d_name = std::string{};
 					if(d_stmt.type == ECSACT_STATEMENT_COMPONENT) {
 						d_name =
 							get_name_from_sv(d_stmt.data.component_statement.component_name);
@@ -1169,14 +1106,15 @@ public:
 				}
 			}
 
-			std::string field_name;
-			std::string field_type_name;
+			auto field_name = std::string{};
+			auto field_type_name = std::string{};
 
 			if(statement.type == ECSACT_STATEMENT_BUILTIN_TYPE_FIELD) {
 				field_name =
 					get_name_from_sv(statement.data.field_statement.field_name);
-				field_type_name =
-					builtin_type_name(statement.data.field_statement.field_type);
+				field_type_name = ecsact::parse::builtin_type_to_keyword_string(
+					statement.data.field_statement.field_type
+				);
 			} else if(statement.type == ECSACT_STATEMENT_USER_TYPE_FIELD) {
 				field_name =
 					get_name_from_sv(statement.data.user_type_field_statement.field_name);
@@ -1198,11 +1136,10 @@ public:
 		}
 
 		return hover{
-			.contents =
-				{
-					.kind = markup_kind::markdown,
-					.value = hover_text,
-				},
+			.contents{
+				.kind = markup_kind::markdown,
+				.value = hover_text,
+			},
 			.range = r,
 		};
 	}
@@ -1260,7 +1197,7 @@ public:
 		}
 
 		// What is the word immediately before the cursor?
-		std::string word_at_cursor;
+		auto word_at_cursor = std::string{};
 		if(pos.character > 0 && pos.character <= current_line.size()) {
 			auto start = pos.character;
 			while(start > 0 &&
@@ -1276,7 +1213,7 @@ public:
 
 		// Determine context from stacks
 		auto const* context_stack = (std::vector<ecsact_statement>*)nullptr;
-		for(auto const& info : doc.stacks) {
+		for(const auto& info : doc.stacks) {
 			if(info.range.start.line < pos.line ||
 				 (info.range.start.line == pos.line &&
 					info.range.start.character <= pos.character)) {
@@ -1291,7 +1228,7 @@ public:
 		bool inside_generates = false;
 
 		if(context_stack) {
-			for(auto const& stmt : *context_stack) {
+			for(const auto& stmt : *context_stack) {
 				if(stmt.type == ECSACT_STATEMENT_SYSTEM) {
 					inside_system = true;
 				}
@@ -1327,7 +1264,7 @@ public:
 				}
 			}
 
-			for(auto const& pkg_name : package_names) {
+			for(const auto& pkg_name : package_names) {
 				result.items.push_back({
 					.label = pkg_name,
 					.kind = completion_item_kind::module,
@@ -1335,72 +1272,29 @@ public:
 				});
 			}
 		} else {
-			static const std::vector<std::string> top_level_keywords = {
-				ECSACT_PARSE_KW_MAIN_PACKAGE,
-				ECSACT_PARSE_KW_PACKAGE,
-				ECSACT_PARSE_KW_IMPORT,
-				ECSACT_PARSE_KW_COMPONENT,
-				ECSACT_PARSE_KW_TRANSIENT,
-				ECSACT_PARSE_KW_SYSTEM,
-				ECSACT_PARSE_KW_ACTION,
-				ECSACT_PARSE_KW_ENUM,
-			};
-
-			static const std::vector<std::string> cap_keywords = {
-				ECSACT_PARSE_KW_READONLY,
-				ECSACT_PARSE_KW_READWRITE,
-				ECSACT_PARSE_KW_WRITEONLY,
-				ECSACT_PARSE_KW_ADDS,
-				ECSACT_PARSE_KW_REMOVES,
-				ECSACT_PARSE_KW_EXCLUDE,
-				ECSACT_PARSE_KW_INCLUDE,
-				ECSACT_PARSE_KW_REQUIRED,
-				ECSACT_PARSE_KW_GENERATES,
-			};
-
-			static const std::vector<std::string> generates_keywords = {
-				ECSACT_PARSE_KW_REQUIRED,
-				ECSACT_PARSE_KW_OPTIONAL,
-			};
-
-			static const std::vector<std::string> type_keywords = {
-				ECSACT_PARSE_KW_BOOL,
-				ECSACT_PARSE_KW_I8,
-				ECSACT_PARSE_KW_U8,
-				ECSACT_PARSE_KW_I16,
-				ECSACT_PARSE_KW_U16,
-				ECSACT_PARSE_KW_I32,
-				ECSACT_PARSE_KW_U32,
-				ECSACT_PARSE_KW_I64,
-				ECSACT_PARSE_KW_U64,
-				ECSACT_PARSE_KW_F32,
-				ECSACT_PARSE_KW_F64,
-				ECSACT_PARSE_KW_ENTITY,
-			};
-
 			// Keyword suggestions - only if we are at the start of the line or
 			// haven't finished a keyword
 			if(word_count_before == 0) {
 				if(!inside_system && !inside_action && !inside_component &&
 					 !inside_enum) {
-					for(auto const& kw : top_level_keywords) {
+					for(const auto& kw : ecsact::parse::top_level_keywords) {
 						result.items.push_back({
-							.label = kw,
+							.label{kw},
 							.kind = completion_item_kind::keyword,
 						});
 					}
 				} else if(inside_system || inside_action) {
 					if(inside_generates) {
-						for(auto const& kw : generates_keywords) {
+						for(const auto& kw : ecsact::parse::generates_keywords) {
 							result.items.push_back({
-								.label = kw,
+								.label{kw},
 								.kind = completion_item_kind::keyword,
 							});
 						}
 					} else {
-						for(auto const& kw : cap_keywords) {
+						for(const auto& kw : ecsact::parse::cap_keywords) {
 							result.items.push_back({
-								.label = kw,
+								.label{kw},
 								.kind = completion_item_kind::keyword,
 							});
 						}
@@ -1412,9 +1306,9 @@ public:
 						}
 					}
 				} else if(inside_component) {
-					for(auto const& kw : type_keywords) {
+					for(const auto& kw : ecsact::parse::type_keywords) {
 						result.items.push_back({
-							.label = kw,
+							.label{kw},
 							.kind = completion_item_kind::class_kind,
 						});
 					}
@@ -1428,13 +1322,13 @@ public:
 				auto first_word = std::string(
 					trimmed_before.substr(0, trimmed_before.find_first_of(" \t"))
 				);
-				for(auto const& kw : cap_keywords) {
+				for(const auto& kw : ecsact::parse::cap_keywords) {
 					if(first_word == kw) {
 						after_cap_kw = true;
 						break;
 					}
 				}
-				for(auto const& kw : generates_keywords) {
+				for(const auto& kw : ecsact::parse::generates_keywords) {
 					if(first_word == kw) {
 						after_cap_kw = true;
 						break;
@@ -1487,7 +1381,7 @@ public:
 					}
 				}
 
-				for(auto const& comp_name : component_names) {
+				for(const auto& comp_name : component_names) {
 					result.items.push_back({
 						.label = comp_name,
 						.kind = completion_item_kind::class_kind,
@@ -1581,9 +1475,9 @@ public:
 				if(info.stack.empty()) {
 					continue;
 				}
-				auto&       d_stmt = info.stack.back();
-				std::string d_name;
-				auto        name_sv = ecsact_statement_sv{};
+				auto& d_stmt = info.stack.back();
+				auto  d_name = std::string{};
+				auto  name_sv = ecsact_statement_sv{};
 				if(d_stmt.type == ECSACT_STATEMENT_COMPONENT) {
 					name_sv = d_stmt.data.component_statement.component_name;
 				} else if(d_stmt.type == ECSACT_STATEMENT_TRANSIENT) {
@@ -1602,8 +1496,8 @@ public:
 					// If the symbol_name has a package prefix, check if this document is
 					// in that package
 					if(last_dot != std::string::npos) {
-						std::string prefix = symbol_name.substr(0, last_dot);
-						bool        pkg_match = false;
+						auto prefix = symbol_name.substr(0, last_dot);
+						auto pkg_match = false;
 						for(auto& info2 : doc_state.stacks) {
 							if(info2.stack.empty()) {
 								continue;

--- a/ecsact_lsp_server/test/workspace_manager_test.cc
+++ b/ecsact_lsp_server/test/workspace_manager_test.cc
@@ -61,12 +61,20 @@ static void expect_no_errors(const nlohmann::json& publish_diagnostics) {
 	}
 }
 
+class WorkspaceManager : public ::testing::Test {
+protected:
+	static void SetUpTestSuite() {
+		ecsact_interpret_reset();
+		ecsact_parse_reset();
+	}
+
+	static void TearDownTestSuite() {
+	}
+};
+
 TEST(WorkspaceManager, ClusterCrashRepro) {
-	ecsact_interpret_reset();
-	mock_sender                   sender;
-	ecsact_interpret_reset();
-	ecsact_parse_reset();
-	ecsact_lsp::workspace_manager manager(std::move(sender));
+	auto sender = mock_sender{};
+	auto manager = ecsact_lsp::workspace_manager{std::move(sender)};
 
 	std::string uri = "file:///test.ecsact";
 	std::string text = R"(
@@ -81,10 +89,8 @@ cluster {
 }
 
 TEST(WorkspaceManager, EmptyCluster) {
-	mock_sender                   sender;
-	ecsact_interpret_reset();
-	ecsact_parse_reset();
-	ecsact_lsp::workspace_manager manager(std::move(sender));
+	auto sender = mock_sender{};
+	auto manager = ecsact_lsp::workspace_manager{std::move(sender)};
 
 	std::string uri = "file:///test_empty.ecsact";
 	std::string text = R"(
@@ -97,10 +103,8 @@ cluster {}
 }
 
 TEST(WorkspaceManager, MultipleClusters) {
-	mock_sender                   sender;
-	ecsact_interpret_reset();
-	ecsact_parse_reset();
-	ecsact_lsp::workspace_manager manager(std::move(sender));
+	auto sender = mock_sender{};
+	auto manager = ecsact_lsp::workspace_manager{std::move(sender)};
 
 	std::string uri = "file:///test_multiple.ecsact";
 	std::string text = R"(
@@ -114,10 +118,8 @@ cluster B {}
 }
 
 TEST(WorkspaceManager, InvalidClusterContext) {
-	mock_sender                   sender;
-	ecsact_interpret_reset();
-	ecsact_parse_reset();
-	ecsact_lsp::workspace_manager manager(std::move(sender));
+	auto sender = mock_sender{};
+	auto manager = ecsact_lsp::workspace_manager{std::move(sender)};
 
 	std::string uri = "file:///test_invalid_ctx.ecsact";
 	std::string text = R"(
@@ -140,10 +142,8 @@ component Foo {
 }
 
 TEST(WorkspaceManager, SyntaxErrorInCluster) {
-	mock_sender                   sender;
-	ecsact_interpret_reset();
-	ecsact_parse_reset();
-	ecsact_lsp::workspace_manager manager(std::move(sender));
+	auto sender = mock_sender{};
+	auto manager = ecsact_lsp::workspace_manager{std::move(sender)};
 
 	std::string uri = "file:///test_syntax_err.ecsact";
 	std::string text = R"(
@@ -166,10 +166,8 @@ cluster {
 }
 
 TEST(WorkspaceManager, StackManagement) {
-	mock_sender                   sender;
-	ecsact_interpret_reset();
-	ecsact_parse_reset();
-	ecsact_lsp::workspace_manager manager(std::move(sender));
+	auto sender = mock_sender{};
+	auto manager = ecsact_lsp::workspace_manager{std::move(sender)};
 
 	std::string uri = "file:///test_stack.ecsact";
 	std::string text = R"(
@@ -183,10 +181,8 @@ component C {}
 }
 
 TEST(WorkspaceManager, ActionNoCapabilities) {
-	mock_sender                   sender;
-	ecsact_interpret_reset();
-	ecsact_parse_reset();
-	ecsact_lsp::workspace_manager manager(std::move(sender));
+	auto sender = mock_sender{};
+	auto manager = ecsact_lsp::workspace_manager{std::move(sender)};
 
 	std::string uri = "file:///action_no_caps.ecsact";
 	std::string text = R"(
@@ -208,9 +204,8 @@ action Foo {}
 }
 
 TEST(WorkspaceManager, ClusterConflict) {
-	mock_sender sender;
-	sender.trace = ecsact_lsp::trace_value::verbose;
-	ecsact_lsp::workspace_manager manager(std::move(sender));
+	auto sender = mock_sender{};
+	auto manager = ecsact_lsp::workspace_manager{std::move(sender)};
 
 	std::string uri = "file:///cluster_conflict.ecsact";
 	std::string text = R"(
@@ -238,10 +233,8 @@ cluster {
 }
 
 TEST(WorkspaceManager, GotoDefinition) {
-	mock_sender                   sender;
-	ecsact_interpret_reset();
-	ecsact_parse_reset();
-	ecsact_lsp::workspace_manager manager(std::move(sender));
+	auto sender = mock_sender{};
+	auto manager = ecsact_lsp::workspace_manager{std::move(sender)};
 
 	std::string uri = "file:///test.ecsact";
 	std::string text = R"(
@@ -303,10 +296,8 @@ system SysB {
 }
 
 TEST(WorkspaceManager, GotoDefinitionMultiFile) {
-	mock_sender                   sender;
-	ecsact_interpret_reset();
-	ecsact_parse_reset();
-	ecsact_lsp::workspace_manager manager(std::move(sender));
+	auto sender = mock_sender{};
+	auto manager = ecsact_lsp::workspace_manager{std::move(sender)};
 
 	std::string uri_a = "file:///a.ecsact";
 	std::string text_a = R"(
@@ -335,9 +326,8 @@ system SysB {
 }
 
 TEST(WorkspaceManager, Hover) {
-	mock_sender                   sender;
-	sender.trace = ecsact_lsp::trace_value::verbose;
-	ecsact_lsp::workspace_manager manager(std::move(sender));
+	auto sender = mock_sender{};
+	auto manager = ecsact_lsp::workspace_manager{std::move(sender)};
 
 	std::string uri = "file:///test.ecsact";
 	std::string text = R"(
@@ -396,10 +386,8 @@ system SysA {
 }
 
 TEST(WorkspaceManager, HoverMultiFile) {
-	mock_sender                   sender;
-	ecsact_interpret_reset();
-	ecsact_parse_reset();
-	ecsact_lsp::workspace_manager manager(std::move(sender));
+	auto sender = mock_sender{};
+	auto manager = ecsact_lsp::workspace_manager{std::move(sender)};
 
 	std::string uri_a = "file:///a.ecsact";
 	std::string text_a = R"(
@@ -429,10 +417,8 @@ system SysB {
 }
 
 TEST(WorkspaceManager, GotoDefinitionImport) {
-	mock_sender                   sender;
-	ecsact_interpret_reset();
-	ecsact_parse_reset();
-	ecsact_lsp::workspace_manager manager(std::move(sender));
+	auto sender = mock_sender{};
+	auto manager = ecsact_lsp::workspace_manager{std::move(sender)};
 
 	std::string uri_a = "file:///a.ecsact";
 	std::string text_a = R"(
@@ -461,10 +447,8 @@ system SysB {
 }
 
 TEST(WorkspaceManager, Completion) {
-	mock_sender                   sender;
-	ecsact_interpret_reset();
-	ecsact_parse_reset();
-	ecsact_lsp::workspace_manager manager(std::move(sender));
+	auto sender = mock_sender{};
+	auto manager = ecsact_lsp::workspace_manager{std::move(sender)};
 
 	std::string uri_a = "file:///a.ecsact";
 	std::string text_a = R"(
@@ -515,10 +499,8 @@ system SysB {
 }
 
 TEST(WorkspaceManager, DotCompletion) {
-	mock_sender                   sender;
-	ecsact_interpret_reset();
-	ecsact_parse_reset();
-	ecsact_lsp::workspace_manager manager(std::move(sender));
+	auto sender = mock_sender{};
+	auto manager = ecsact_lsp::workspace_manager{std::move(sender)};
 
 	std::string uri_a = "file:///a.ecsact";
 	std::string text_a = R"(
@@ -552,9 +534,8 @@ system SysB {
 }
 
 TEST(WorkspaceManager, KeywordCompletion) {
-	mock_sender sender;
-	sender.trace = ecsact_lsp::trace_value::verbose;
-	ecsact_lsp::workspace_manager manager(std::move(sender));
+	auto sender = mock_sender{};
+	auto manager = ecsact_lsp::workspace_manager{std::move(sender)};
 
 	std::string uri = "file:///test.ecsact";
 	std::string text = "package test;\n\n";
@@ -580,10 +561,8 @@ TEST(WorkspaceManager, KeywordCompletion) {
 }
 
 TEST(WorkspaceManager, KeywordCompletionInsideBlock) {
-	mock_sender                   sender;
-	ecsact_interpret_reset();
-	ecsact_parse_reset();
-	ecsact_lsp::workspace_manager manager(std::move(sender));
+	auto sender = mock_sender{};
+	auto manager = ecsact_lsp::workspace_manager{std::move(sender)};
 
 	std::string uri = "file:///test.ecsact";
 	std::string text = R"(
@@ -619,9 +598,8 @@ system SysA {
 }
 
 TEST(WorkspaceManager, FieldCompletion) {
-	mock_sender                   sender;
-	sender.trace = ecsact_lsp::trace_value::verbose;
-	ecsact_lsp::workspace_manager manager(std::move(sender));
+	auto sender = mock_sender{};
+	auto manager = ecsact_lsp::workspace_manager{std::move(sender)};
 
 	std::string uri = "file:///test.ecsact";
 	std::string text = R"(
@@ -640,11 +618,16 @@ component CompA {
 	bool found_i32 = false;
 	bool found_component_kw = false;
 	for(auto const& item : result->items) {
-		if(item.label == "i32") found_i32 = true;
-		if(item.label == "component") found_component_kw = true;
+		if(item.label == "i32") {
+			found_i32 = true;
+		}
+		if(item.label == "component") {
+			found_component_kw = true;
+		}
 	}
 	EXPECT_TRUE(found_i32);
-	EXPECT_FALSE(found_component_kw); // Should not suggest top-level keywords here
+	EXPECT_FALSE(found_component_kw); // Should not suggest top-level keywords
+																		// here
 
 	// Typing 'i' inside component
 	// Cursor at line 3, col 2 (after the 'i')
@@ -659,7 +642,9 @@ component CompA {
 	ASSERT_TRUE(result.has_value());
 	found_i32 = false;
 	for(auto const& item : result->items) {
-		if(item.label == "i32") found_i32 = true;
+		if(item.label == "i32") {
+			found_i32 = true;
+		}
 	}
 	EXPECT_TRUE(found_i32);
 
@@ -684,10 +669,8 @@ component CompA {
 }
 
 TEST(WorkspaceManager, SystemCapabilityCompletion) {
-	mock_sender                   sender;
-	ecsact_interpret_reset();
-	ecsact_parse_reset();
-	ecsact_lsp::workspace_manager manager(std::move(sender));
+	auto sender = mock_sender{};
+	auto manager = ecsact_lsp::workspace_manager{std::move(sender)};
 
 	std::string uri = "file:///test.ecsact";
 	std::string text = R"(
@@ -714,7 +697,9 @@ system SysA {
 	ASSERT_TRUE(result.has_value());
 	bool found_readonly = false;
 	for(auto const& item : result->items) {
-		if(item.label == "readonly") found_readonly = true;
+		if(item.label == "readonly") {
+			found_readonly = true;
+		}
 	}
 	EXPECT_TRUE(found_readonly);
 
@@ -732,7 +717,9 @@ system SysA {
 	ASSERT_TRUE(result.has_value());
 	bool found_comp_a = false;
 	for(auto const& item : result->items) {
-		if(item.label == "CompA") found_comp_a = true;
+		if(item.label == "CompA") {
+			found_comp_a = true;
+		}
 	}
 	EXPECT_TRUE(found_comp_a);
 }

--- a/ecsact_lsp_server/test/workspace_manager_test.cc
+++ b/ecsact_lsp_server/test/workspace_manager_test.cc
@@ -33,6 +33,7 @@ struct mock_sender {
 	}
 
 	void log_message(ecsact_lsp::message_type type, std::string message) {
+		std::cerr << "[LSP LOG] " << message << "\n";
 		last_log_message = message;
 	}
 
@@ -61,7 +62,10 @@ static void expect_no_errors(const nlohmann::json& publish_diagnostics) {
 }
 
 TEST(WorkspaceManager, ClusterCrashRepro) {
+	ecsact_interpret_reset();
 	mock_sender                   sender;
+	ecsact_interpret_reset();
+	ecsact_parse_reset();
 	ecsact_lsp::workspace_manager manager(std::move(sender));
 
 	std::string uri = "file:///test.ecsact";
@@ -78,6 +82,8 @@ cluster {
 
 TEST(WorkspaceManager, EmptyCluster) {
 	mock_sender                   sender;
+	ecsact_interpret_reset();
+	ecsact_parse_reset();
 	ecsact_lsp::workspace_manager manager(std::move(sender));
 
 	std::string uri = "file:///test_empty.ecsact";
@@ -92,6 +98,8 @@ cluster {}
 
 TEST(WorkspaceManager, MultipleClusters) {
 	mock_sender                   sender;
+	ecsact_interpret_reset();
+	ecsact_parse_reset();
 	ecsact_lsp::workspace_manager manager(std::move(sender));
 
 	std::string uri = "file:///test_multiple.ecsact";
@@ -107,6 +115,8 @@ cluster B {}
 
 TEST(WorkspaceManager, InvalidClusterContext) {
 	mock_sender                   sender;
+	ecsact_interpret_reset();
+	ecsact_parse_reset();
 	ecsact_lsp::workspace_manager manager(std::move(sender));
 
 	std::string uri = "file:///test_invalid_ctx.ecsact";
@@ -131,6 +141,8 @@ component Foo {
 
 TEST(WorkspaceManager, SyntaxErrorInCluster) {
 	mock_sender                   sender;
+	ecsact_interpret_reset();
+	ecsact_parse_reset();
 	ecsact_lsp::workspace_manager manager(std::move(sender));
 
 	std::string uri = "file:///test_syntax_err.ecsact";
@@ -155,6 +167,8 @@ cluster {
 
 TEST(WorkspaceManager, StackManagement) {
 	mock_sender                   sender;
+	ecsact_interpret_reset();
+	ecsact_parse_reset();
 	ecsact_lsp::workspace_manager manager(std::move(sender));
 
 	std::string uri = "file:///test_stack.ecsact";
@@ -170,6 +184,8 @@ component C {}
 
 TEST(WorkspaceManager, ActionNoCapabilities) {
 	mock_sender                   sender;
+	ecsact_interpret_reset();
+	ecsact_parse_reset();
 	ecsact_lsp::workspace_manager manager(std::move(sender));
 
 	std::string uri = "file:///action_no_caps.ecsact";
@@ -223,6 +239,8 @@ cluster {
 
 TEST(WorkspaceManager, GotoDefinition) {
 	mock_sender                   sender;
+	ecsact_interpret_reset();
+	ecsact_parse_reset();
 	ecsact_lsp::workspace_manager manager(std::move(sender));
 
 	std::string uri = "file:///test.ecsact";
@@ -286,6 +304,8 @@ system SysB {
 
 TEST(WorkspaceManager, GotoDefinitionMultiFile) {
 	mock_sender                   sender;
+	ecsact_interpret_reset();
+	ecsact_parse_reset();
 	ecsact_lsp::workspace_manager manager(std::move(sender));
 
 	std::string uri_a = "file:///a.ecsact";
@@ -316,6 +336,7 @@ system SysB {
 
 TEST(WorkspaceManager, Hover) {
 	mock_sender                   sender;
+	sender.trace = ecsact_lsp::trace_value::verbose;
 	ecsact_lsp::workspace_manager manager(std::move(sender));
 
 	std::string uri = "file:///test.ecsact";
@@ -357,6 +378,13 @@ system SysA {
 		<< result->contents.value;
 	ASSERT_TRUE(result->contents.value.find("test.SysA") != std::string::npos)
 		<< result->contents.value;
+	ASSERT_TRUE(
+		result->contents.value.find("**Execution Batch 0 systems:**") !=
+		std::string::npos
+	) << result->contents.value;
+	ASSERT_TRUE(
+		result->contents.value.find("- **`test.SysA`** (this)") != std::string::npos
+	) << result->contents.value;
 
 	// Hover over CompA in SysA (system capability)
 	result = manager.get_hover(uri, {8, 12});
@@ -369,6 +397,8 @@ system SysA {
 
 TEST(WorkspaceManager, HoverMultiFile) {
 	mock_sender                   sender;
+	ecsact_interpret_reset();
+	ecsact_parse_reset();
 	ecsact_lsp::workspace_manager manager(std::move(sender));
 
 	std::string uri_a = "file:///a.ecsact";
@@ -400,6 +430,8 @@ system SysB {
 
 TEST(WorkspaceManager, GotoDefinitionImport) {
 	mock_sender                   sender;
+	ecsact_interpret_reset();
+	ecsact_parse_reset();
 	ecsact_lsp::workspace_manager manager(std::move(sender));
 
 	std::string uri_a = "file:///a.ecsact";
@@ -430,6 +462,8 @@ system SysB {
 
 TEST(WorkspaceManager, Completion) {
 	mock_sender                   sender;
+	ecsact_interpret_reset();
+	ecsact_parse_reset();
 	ecsact_lsp::workspace_manager manager(std::move(sender));
 
 	std::string uri_a = "file:///a.ecsact";
@@ -482,6 +516,8 @@ system SysB {
 
 TEST(WorkspaceManager, DotCompletion) {
 	mock_sender                   sender;
+	ecsact_interpret_reset();
+	ecsact_parse_reset();
 	ecsact_lsp::workspace_manager manager(std::move(sender));
 
 	std::string uri_a = "file:///a.ecsact";
@@ -545,6 +581,8 @@ TEST(WorkspaceManager, KeywordCompletion) {
 
 TEST(WorkspaceManager, KeywordCompletionInsideBlock) {
 	mock_sender                   sender;
+	ecsact_interpret_reset();
+	ecsact_parse_reset();
 	ecsact_lsp::workspace_manager manager(std::move(sender));
 
 	std::string uri = "file:///test.ecsact";
@@ -578,4 +616,123 @@ system SysA {
 	EXPECT_TRUE(found_readonly);
 	EXPECT_TRUE(found_readwrite);
 	EXPECT_TRUE(found_generates);
+}
+
+TEST(WorkspaceManager, FieldCompletion) {
+	mock_sender                   sender;
+	sender.trace = ecsact_lsp::trace_value::verbose;
+	ecsact_lsp::workspace_manager manager(std::move(sender));
+
+	std::string uri = "file:///test.ecsact";
+	std::string text = R"(
+package test;
+component CompA {
+	
+}
+)";
+
+	manager.add_document(uri, 1, text);
+
+	// Typing 'i' inside component
+	// Cursor at line 3, col 1
+	auto result = manager.get_completions(uri, {3, 1});
+	ASSERT_TRUE(result.has_value());
+	bool found_i32 = false;
+	bool found_component_kw = false;
+	for(auto const& item : result->items) {
+		if(item.label == "i32") found_i32 = true;
+		if(item.label == "component") found_component_kw = true;
+	}
+	EXPECT_TRUE(found_i32);
+	EXPECT_FALSE(found_component_kw); // Should not suggest top-level keywords here
+
+	// Typing 'i' inside component
+	// Cursor at line 3, col 2 (after the 'i')
+	text = R"(
+package test;
+component CompA {
+	i
+}
+)";
+	manager.update_document(uri, 3, text);
+	result = manager.get_completions(uri, {3, 2});
+	ASSERT_TRUE(result.has_value());
+	found_i32 = false;
+	for(auto const& item : result->items) {
+		if(item.label == "i32") found_i32 = true;
+	}
+	EXPECT_TRUE(found_i32);
+
+	// Typing 'i32 ' inside component
+	// Cursor at line 3, col 5
+	text = R"(
+package test;
+component CompA {
+	i32 
+}
+)";
+	manager.update_document(uri, 2, text);
+	result = manager.get_completions(uri, {3, 5});
+	// Should NOT suggest anything (let the user type the field name)
+	// or at least not keywords
+	if(result.has_value()) {
+		for(auto const& item : result->items) {
+			EXPECT_NE(item.kind, ecsact_lsp::completion_item_kind::keyword)
+				<< "Unexpected keyword suggestion: " << item.label;
+		}
+	}
+}
+
+TEST(WorkspaceManager, SystemCapabilityCompletion) {
+	mock_sender                   sender;
+	ecsact_interpret_reset();
+	ecsact_parse_reset();
+	ecsact_lsp::workspace_manager manager(std::move(sender));
+
+	std::string uri = "file:///test.ecsact";
+	std::string text = R"(
+package test;
+component CompA { i32 a; }
+system SysA {
+	
+}
+)";
+
+	manager.add_document(uri, 1, text);
+
+	// Typing 'r' inside system
+	// Cursor at line 4, col 1
+	text = R"(
+package test;
+component CompA { i32 a; }
+system SysA {
+	r
+}
+)";
+	manager.update_document(uri, 2, text);
+	auto result = manager.get_completions(uri, {4, 2});
+	ASSERT_TRUE(result.has_value());
+	bool found_readonly = false;
+	for(auto const& item : result->items) {
+		if(item.label == "readonly") found_readonly = true;
+	}
+	EXPECT_TRUE(found_readonly);
+
+	// Typing 'readonly ' inside system
+	// Cursor at line 4, col 10
+	text = R"(
+package test;
+component CompA { i32 a; }
+system SysA {
+	readonly 
+}
+)";
+	manager.update_document(uri, 3, text);
+	result = manager.get_completions(uri, {4, 10});
+	ASSERT_TRUE(result.has_value());
+	bool found_comp_a = false;
+	for(auto const& item : result->items) {
+		if(item.label == "CompA") found_comp_a = true;
+	}
+	EXPECT_TRUE(found_comp_a);
 }

--- a/ecsact_parse/ecsact/ecsact_parse_statement.cc
+++ b/ecsact_parse/ecsact/ecsact_parse_statement.cc
@@ -8,6 +8,12 @@
 
 using namespace ecsact::parse::detail;
 
+static int32_t last_id = 0;
+
+void ecsact_parse_reset() {
+	last_id = 0;
+}
+
 template<typename Fn>
 static auto context_grammar(ecsact_statement_type context_type, Fn&& fn) {
 	switch(context_type) {
@@ -25,14 +31,6 @@ static auto context_grammar(ecsact_statement_type context_type, Fn&& fn) {
 			return fn(grammar::system_level_statement{});
 		case ECSACT_STATEMENT_ACTION:
 			return fn(grammar::action_level_statement{});
-		case ECSACT_STATEMENT_SYSTEM_GENERATES:
-			return fn(grammar::system_generates_level_statement{});
-		case ECSACT_STATEMENT_ENTITY_FIELD:
-			return fn(grammar::entity_field_level_statement{});
-		case ECSACT_STATEMENT_SYSTEM_COMPONENT:
-			return fn(grammar::system_component_level_statement{});
-		case ECSACT_STATEMENT_SYSTEM_WITH:
-			return fn(grammar::system_with_level_statement{});
 		case ECSACT_STATEMENT_PACKAGE:
 			return fn(grammar::package_level_statement{});
 		case ECSACT_STATEMENT_IMPORT:
@@ -43,8 +41,16 @@ static auto context_grammar(ecsact_statement_type context_type, Fn&& fn) {
 			return fn(grammar::builtin_type_field_level_statement{});
 		case ECSACT_STATEMENT_USER_TYPE_FIELD:
 			return fn(grammar::user_type_field_level_statement{});
+		case ECSACT_STATEMENT_SYSTEM_COMPONENT:
+			return fn(grammar::system_component_level_statement{});
+		case ECSACT_STATEMENT_SYSTEM_GENERATES:
+			return fn(grammar::system_generates_level_statement{});
+		case ECSACT_STATEMENT_SYSTEM_WITH:
+			return fn(grammar::system_with_level_statement{});
 		case ECSACT_STATEMENT_ENTITY_CONSTRAINT:
 			return fn(grammar::entity_constraint_level_statement{});
+		case ECSACT_STATEMENT_ENTITY_FIELD:
+			return fn(grammar::entity_field_level_statement{});
 		case ECSACT_STATEMENT_SYSTEM_NOTIFY:
 			return fn(grammar::system_notify_level_statement{});
 		case ECSACT_STATEMENT_SYSTEM_NOTIFY_COMPONENT:
@@ -64,8 +70,6 @@ int ecsact_parse_statement(
 	ecsact_statement*       out_statement,
 	ecsact_parse_status*    out_status
 ) {
-	static decltype(out_statement->id) last_id{};
-
 	const auto context_type = context_statement == nullptr
 		? ECSACT_STATEMENT_NONE
 		: context_statement->type;

--- a/ecsact_parse/ecsact/parse.h
+++ b/ecsact_parse/ecsact/parse.h
@@ -22,7 +22,7 @@
  *        parsing `statement_string`. May be `NULL`.
  * @returns read length
  */
-ECSACT_PARSE_API int32_t ecsact_parse_statement(
+ECSACT_PARSE_API int ecsact_parse_statement(
 	const char*             statement_string,
 	int                     max_read_length,
 	const ecsact_statement* context_statement,
@@ -30,4 +30,7 @@ ECSACT_PARSE_API int32_t ecsact_parse_statement(
 	ecsact_parse_status*    out_status
 );
 
+ECSACT_PARSE_API void ecsact_parse_reset();
+
 #endif // ECSACT_PARSER_H
+

--- a/ecsact_parse/ecsact/parse.h
+++ b/ecsact_parse/ecsact/parse.h
@@ -33,4 +33,3 @@ ECSACT_PARSE_API int ecsact_parse_statement(
 ECSACT_PARSE_API void ecsact_parse_reset();
 
 #endif // ECSACT_PARSER_H
-

--- a/ecsact_parse/ecsact/parse/keywords.h
+++ b/ecsact_parse/ecsact/parse/keywords.h
@@ -39,10 +39,11 @@
 #ifdef __cplusplus
 #	include <string>
 #	include <string_view>
+#	include <array>
 
 namespace ecsact::parse {
 
-inline auto builtin_type_to_string(ecsact_builtin_type type)
+constexpr auto builtin_type_to_keyword_string(ecsact_builtin_type type)
 	-> std::string_view {
 	switch(type) {
 		case ECSACT_BOOL:
@@ -70,8 +71,52 @@ inline auto builtin_type_to_string(ecsact_builtin_type type)
 		case ECSACT_ENTITY_TYPE:
 			return ECSACT_PARSE_KW_ENTITY;
 	}
+
 	return "unknown";
 }
+
+constexpr auto top_level_keywords = std::array{
+	std::string_view{ECSACT_PARSE_KW_MAIN_PACKAGE},
+	std::string_view{ECSACT_PARSE_KW_PACKAGE},
+	std::string_view{ECSACT_PARSE_KW_IMPORT},
+	std::string_view{ECSACT_PARSE_KW_COMPONENT},
+	std::string_view{ECSACT_PARSE_KW_TRANSIENT},
+	std::string_view{ECSACT_PARSE_KW_SYSTEM},
+	std::string_view{ECSACT_PARSE_KW_ACTION},
+	std::string_view{ECSACT_PARSE_KW_ENUM},
+};
+
+constexpr auto cap_keywords = std::array{
+	std::string_view{ECSACT_PARSE_KW_READONLY},
+	std::string_view{ECSACT_PARSE_KW_READWRITE},
+	std::string_view{ECSACT_PARSE_KW_WRITEONLY},
+	std::string_view{ECSACT_PARSE_KW_ADDS},
+	std::string_view{ECSACT_PARSE_KW_REMOVES},
+	std::string_view{ECSACT_PARSE_KW_EXCLUDE},
+	std::string_view{ECSACT_PARSE_KW_INCLUDE},
+	std::string_view{ECSACT_PARSE_KW_REQUIRED},
+	std::string_view{ECSACT_PARSE_KW_GENERATES},
+};
+
+constexpr auto generates_keywords = std::array{
+	std::string_view{ECSACT_PARSE_KW_REQUIRED},
+	std::string_view{ECSACT_PARSE_KW_OPTIONAL},
+};
+
+constexpr auto type_keywords = std::array{
+	std::string_view{ECSACT_PARSE_KW_BOOL},
+	std::string_view{ECSACT_PARSE_KW_I8},
+	std::string_view{ECSACT_PARSE_KW_U8},
+	std::string_view{ECSACT_PARSE_KW_I16},
+	std::string_view{ECSACT_PARSE_KW_U16},
+	std::string_view{ECSACT_PARSE_KW_I32},
+	std::string_view{ECSACT_PARSE_KW_U32},
+	std::string_view{ECSACT_PARSE_KW_I64},
+	std::string_view{ECSACT_PARSE_KW_U64},
+	std::string_view{ECSACT_PARSE_KW_F32},
+	std::string_view{ECSACT_PARSE_KW_F64},
+	std::string_view{ECSACT_PARSE_KW_ENTITY},
+};
 
 } // namespace ecsact::parse
 #endif

--- a/ecsact_parse/ecsact/parse/statements.h
+++ b/ecsact_parse/ecsact/parse/statements.h
@@ -187,4 +187,51 @@ typedef struct ecsact_statement {
 	ecsact_statement_parameter parameters[16];
 } ecsact_statement;
 
+inline const char* ecsact_parse_statement_type_name_pretty(
+	ecsact_statement_type type
+) {
+	switch(type) {
+		case ECSACT_STATEMENT_NONE:
+			return "none";
+		case ECSACT_STATEMENT_UNKNOWN:
+			return "unknown";
+		case ECSACT_STATEMENT_PACKAGE:
+			return "package";
+		case ECSACT_STATEMENT_IMPORT:
+			return "import";
+		case ECSACT_STATEMENT_COMPONENT:
+			return "component";
+		case ECSACT_STATEMENT_TRANSIENT:
+			return "transient";
+		case ECSACT_STATEMENT_SYSTEM:
+			return "system";
+		case ECSACT_STATEMENT_ACTION:
+			return "action";
+		case ECSACT_STATEMENT_ENUM:
+			return "enum";
+		case ECSACT_STATEMENT_ENUM_VALUE:
+			return "enum value";
+		case ECSACT_STATEMENT_BUILTIN_TYPE_FIELD:
+		case ECSACT_STATEMENT_USER_TYPE_FIELD:
+		case ECSACT_STATEMENT_ENTITY_FIELD:
+			return "field";
+		case ECSACT_STATEMENT_SYSTEM_COMPONENT:
+			return "system capability";
+		case ECSACT_STATEMENT_SYSTEM_GENERATES:
+			return "generates";
+		case ECSACT_STATEMENT_SYSTEM_WITH:
+			return "with";
+		case ECSACT_STATEMENT_ENTITY_CONSTRAINT:
+			return "entity constraint";
+		case ECSACT_STATEMENT_SYSTEM_NOTIFY:
+			return "system notify";
+		case ECSACT_STATEMENT_SYSTEM_NOTIFY_COMPONENT:
+			return "system notify component";
+		case ECSACT_STATEMENT_CLUSTER:
+			return "cluster";
+	}
+
+	return "unknown statement";
+}
+
 #endif // ECSACT_PARSE_STATEMENTS_H

--- a/ecsact_runtime/ecsact/runtime/dynamic.h
+++ b/ecsact_runtime/ecsact/runtime/dynamic.h
@@ -598,8 +598,8 @@ ECSACT_DYNAMIC_API_FN(
 );
 
 /**
- * Resets the ecsact interpret state. This will destroy all packages, components,
- * systems, etc.
+ * Resets the ecsact interpret state. This will destroy all packages,
+ * components, systems, etc.
  */
 ECSACT_DYNAMIC_API_FN(void, ecsact_interpret_reset)();
 

--- a/ecsact_runtime/ecsact/runtime/dynamic.h
+++ b/ecsact_runtime/ecsact/runtime/dynamic.h
@@ -597,6 +597,12 @@ ECSACT_DYNAMIC_API_FN(
 	ecsact_system_like_id system_id
 );
 
+/**
+ * Resets the ecsact interpret state. This will destroy all packages, components,
+ * systems, etc.
+ */
+ECSACT_DYNAMIC_API_FN(void, ecsact_interpret_reset)();
+
 // # BEGIN FOR_EACH_ECSACT_DYNAMIC_API_FN
 #ifdef ECSACT_MSVC_TRADITIONAL
 #	define FOR_EACH_ECSACT_DYNAMIC_API_FN(fn, ...) \
@@ -659,7 +665,8 @@ ECSACT_DYNAMIC_API_FN(
 		fn(ecsact_create_system_cluster, __VA_ARGS__);                  \
 		fn(ecsact_add_system_to_cluster, __VA_ARGS__);                  \
 		fn(ecsact_check_execution_batches, __VA_ARGS__);                \
-		fn(ecsact_check_system_execution_batches, __VA_ARGS__)
+		fn(ecsact_check_system_execution_batches, __VA_ARGS__);         \
+		fn(ecsact_interpret_reset, __VA_ARGS__)
 #endif
 
 #endif // ECSACT_RUNTIME_DYNAMIC_H


### PR DESCRIPTION
neede a way to reset global state for lsp sake